### PR TITLE
Removes some of the allow(unsafe_code) boilerplate.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,9 +331,10 @@
 //! [cons-list]: https://en.wikipedia.org/wiki/Cons#Lists
 
 #![forbid(rust_2018_idioms)]
-#![deny(unsafe_code, nonstandard_style)]
+#![deny(nonstandard_style)]
 #![warn(unreachable_pub, missing_docs)]
 #![cfg_attr(has_specialisation, feature(specialization))]
+#![cfg_attr(not(feature = "pool"), deny(unsafe_code))]
 
 #[cfg(test)]
 #[macro_use]

--- a/src/nodes/btree.rs
+++ b/src/nodes/btree.rs
@@ -50,12 +50,10 @@ pub(crate) struct Node<A> {
 }
 
 #[cfg(feature = "pool")]
-#[allow(unsafe_code)]
 unsafe fn cast_uninit<A>(target: &mut A) -> &mut mem::MaybeUninit<A> {
     &mut *(target as *mut A as *mut mem::MaybeUninit<A>)
 }
 
-#[allow(unsafe_code)]
 impl<A> PoolDefault for Node<A> {
     #[cfg(feature = "pool")]
     unsafe fn default_uninit(target: &mut mem::MaybeUninit<Self>) {
@@ -66,7 +64,6 @@ impl<A> PoolDefault for Node<A> {
     }
 }
 
-#[allow(unsafe_code)]
 impl<A> PoolClone for Node<A>
 where
     A: Clone,

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,8 +5,7 @@
 // Every codebase needs a `util` module.
 
 use std::cmp::Ordering;
-use std::ops::{Bound, IndexMut, Range, RangeBounds};
-use std::ptr;
+use std::ops::{Bound, Range, RangeBounds};
 
 #[cfg(feature = "pool")]
 pub(crate) use refpool::{PoolClone, PoolDefault};
@@ -30,27 +29,6 @@ where
 pub(crate) enum Side {
     Left,
     Right,
-}
-
-/// Swap two values of anything implementing `IndexMut`.
-///
-/// Like `slice::swap`, but more generic.
-#[allow(unsafe_code)]
-pub(crate) fn swap_indices<V>(vector: &mut V, a: usize, b: usize)
-where
-    V: IndexMut<usize>,
-    V::Output: Sized,
-{
-    if a == b {
-        return;
-    }
-    // so sorry, but there's no implementation for this in std that's
-    // sufficiently generic
-    let pa: *mut V::Output = &mut vector[a];
-    let pb: *mut V::Output = &mut vector[b];
-    unsafe {
-        ptr::swap(pa, pb);
-    }
 }
 
 #[allow(dead_code)]

--- a/src/vector/focus.rs
+++ b/src/vector/focus.rs
@@ -277,9 +277,7 @@ impl<A> Clone for TreeFocus<A> {
     }
 }
 
-#[allow(unsafe_code)]
 unsafe impl<A: Send> Send for TreeFocus<A> {}
-#[allow(unsafe_code)]
 unsafe impl<A: Sync> Sync for TreeFocus<A> {}
 
 #[inline]
@@ -366,7 +364,6 @@ where
         }
     }
 
-    #[allow(unsafe_code)]
     fn get_focus(&self) -> &Chunk<A> {
         unsafe { &*self.target_ptr }
     }
@@ -559,7 +556,6 @@ where
     /// vec.focus_mut().pair(1, 3, |a, b| *a += *b);
     /// assert_eq!(vector![1, 6, 3, 4, 5], vec);
     /// ```
-    #[allow(unsafe_code)]
     pub fn pair<F, B>(&mut self, a: usize, b: usize, mut f: F) -> B
     where
         F: FnMut(&mut A, &mut A) -> B,
@@ -589,7 +585,6 @@ where
     /// vec.focus_mut().triplet(0, 2, 4, |a, b, c| *a += *b + *c);
     /// assert_eq!(vector![9, 2, 3, 4, 5], vec);
     /// ```
-    #[allow(unsafe_code)]
     pub fn triplet<F, B>(&mut self, a: usize, b: usize, c: usize, mut f: F) -> B
     where
         F: FnMut(&mut A, &mut A, &mut A) -> B,
@@ -796,7 +791,6 @@ where
     fn split_at(self, index: usize) -> (Self, Self) {
         let len = self.len();
         debug_assert!(index <= len);
-        #[allow(unsafe_code)]
         let left = TreeFocusMut {
             view: self.view.start..(self.view.start + index),
             middle_range: self.middle_range.clone(),
@@ -869,7 +863,6 @@ where
         }
     }
 
-    #[allow(unsafe_code)]
     fn get_focus(&mut self) -> &mut Chunk<A> {
         unsafe { &mut *self.target_ptr.load(Ordering::Relaxed) }
     }


### PR DESCRIPTION
This also deletes swap_indices, which is unsound even though it was
neither public nor used in an unsound way.

Fixes #24 