### PR TITLE
Adds a collection of information about the Focus and FocusMut internals

### DIFF
--- a/src/vector/focus.rs
+++ b/src/vector/focus.rs
@@ -482,7 +482,7 @@ pub enum FocusMut<'a, A> {
     /// The Single variant is a focusmut of a simple Vector that can be represented as a single slice.
     Single(RRBPool<A>, &'a mut [A]),
     #[doc(hidden)]
-    /// The Full variant is a focus of a more complex Vector that cannot be represented as a single slcice.
+    /// The Full variant is a focus of a more complex Vector that cannot be represented as a single slice.
     Full(RRBPool<A>, TreeFocusMut<'a, A>),
 }
 


### PR DESCRIPTION
This documents some of the internals of the Focus and FocusMut. Each attribute of the Focus/FocusMut is documented including all of their private methods.