### PR TITLE
Implement From array

### DIFF
--- a/src/hash/set.rs
+++ b/src/hash/set.rs
@@ -950,6 +950,16 @@ where
     }
 }
 
+impl<A, S, const N: usize> From<[A;N]> for HashSet<A, S>
+where
+    A: Hash + Eq + Clone,
+    S: BuildHasher + Default,
+{
+    fn from(arr: [A; N]) -> Self {
+        IntoIterator::into_iter(arr).collect()
+    }
+}
+
 impl<'a, A, S> From<&'a [A]> for HashSet<A, S>
 where
     A: Hash + Eq + Clone,


### PR DESCRIPTION
Implement From for arrays to conveniently initialize a set ```[1,2,3].into()```.
Like collections::HashSet does.