### PR TITLE
Vector impls From array [A;N]

### DIFF
--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -2019,6 +2019,15 @@ where
     }
 }
 
+impl<A, const N: usize> From<[A; N]> for Vector<A>
+where
+    A: Clone,
+{
+    fn from(arr: [A; N]) -> Self {
+        IntoIterator::into_iter(arr).collect()
+    }
+}
+
 impl<'a, A: Clone> From<&'a [A]> for Vector<A> {
     fn from(slice: &[A]) -> Self {
         slice.iter().cloned().collect()


### PR DESCRIPTION
In a previous PR I added an impl from array for HashSet but not for Vector (sorry!). This allows easy initialization like

```
[1,2].into()
```