### PR TITLE
deprecate the `difference` function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2022-04-19
+
+### Deprecated
+- The `difference` alias for `symmetric_difference` has been deprecated.
+
+    To avoid conflicting with the *std* library where `difference` is equivalent
+    to *imbl*'s `relative_complement`.
+
+
 ## [2.0.0] - 2022-04-12
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imbl"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Bodil Stokke <bodil@bodil.org>", "Joe Neeman <joeneeman@gmail.com>"]
 edition = "2018"
 license = "MPL-2.0+"

--- a/src/hash/map.rs
+++ b/src/hash/map.rs
@@ -1112,6 +1112,10 @@ where
     /// ```
     ///
     /// [symmetric_difference]: #method.symmetric_difference
+    #[deprecated(
+        since = "2.0.1",
+        note = "to avoid conflicting behaviors between std and imbl, the `difference` alias for `symmetric_difference` will be removed."
+    )]
     #[inline]
     #[must_use]
     pub fn difference(self, other: Self) -> Self {
@@ -1148,6 +1152,10 @@ where
     /// Time: O(n log n)
     ///
     /// [symmetric_difference_with]: #method.symmetric_difference_with
+    #[deprecated(
+        since = "2.0.1",
+        note = "to avoid conflicting behaviors between std and imbl, the `difference_with` alias for `symmetric_difference_with` will be removed."
+    )]
     #[inline]
     #[must_use]
     pub fn difference_with<F>(self, other: Self, f: F) -> Self
@@ -1195,6 +1203,10 @@ where
     /// ```
     ///
     /// [symmetric_difference_with_key]: #method.symmetric_difference_with_key
+    #[deprecated(
+        since = "2.0.1",
+        note = "to avoid conflicting behaviors between std and imbl, the `difference_with_key` alias for `symmetric_difference_with_key` will be removed."
+    )]
     #[must_use]
     pub fn difference_with_key<F>(self, other: Self, f: F) -> Self
     where

--- a/src/hash/set.rs
+++ b/src/hash/set.rs
@@ -554,6 +554,10 @@ where
     /// ```
     ///
     /// [symmetric_difference]: #method.symmetric_difference
+    #[deprecated(
+        since = "2.0.1",
+        note = "to avoid conflicting behaviors between std and imbl, the `difference` alias for `symmetric_difference` will be removed."
+    )]
     #[must_use]
     pub fn difference(self, other: Self) -> Self {
         self.symmetric_difference(other)

--- a/src/ord/map.rs
+++ b/src/ord/map.rs
@@ -1155,6 +1155,10 @@ where
     /// ```
     ///
     /// [symmetric_difference]: #method.symmetric_difference
+    #[deprecated(
+        since = "2.0.1",
+        note = "to avoid conflicting behaviors between std and imbl, the `difference` alias for `symmetric_difference` will be removed."
+    )]
     #[inline]
     #[must_use]
     pub fn difference(self, other: Self) -> Self {
@@ -1191,6 +1195,10 @@ where
     /// Time: O(n log n)
     ///
     /// [symmetric_difference_with]: #method.symmetric_difference_with
+    #[deprecated(
+        since = "2.0.1",
+        note = "to avoid conflicting behaviors between std and imbl, the `difference_with` alias for `symmetric_difference_with` will be removed."
+    )]
     #[inline]
     #[must_use]
     pub fn difference_with<F>(self, other: Self, f: F) -> Self
@@ -1237,6 +1245,10 @@ where
     /// ));
     /// ```
     /// [symmetric_difference_with_key]: #method.symmetric_difference_with_key
+    #[deprecated(
+        since = "2.0.1",
+        note = "to avoid conflicting behaviors between std and imbl, the `difference_with_key` alias for `symmetric_difference_with_key` will be removed."
+    )]
     #[must_use]
     pub fn difference_with_key<F>(self, other: Self, f: F) -> Self
     where

--- a/src/ord/set.rs
+++ b/src/ord/set.rs
@@ -674,6 +674,10 @@ where
     /// ```
     ///
     /// [symmetric_difference]: #method.symmetric_difference
+    #[deprecated(
+        since = "2.0.1",
+        note = "to avoid conflicting behaviors between std and imbl, the `difference` alias for `symmetric_difference` will be removed."
+    )]
     #[must_use]
     pub fn difference(self, other: Self) -> Self {
         self.symmetric_difference(other)


### PR DESCRIPTION
Here is a PR as promised in issue #56 

I'd still like to go through the docs, and see if anything else jumps out at me, and wait for feedback from others though.

Edit: The only usages of it are in the doctests for the alias itself afaict.