### PR TITLE
Fix clippy lints

### DIFF
--- a/benches/vector.rs
+++ b/benches/vector.rs
@@ -294,7 +294,7 @@ fn vector_get_seq_focus_mut(b: &mut Bencher, count: usize) {
     let mut focus = vec.focus_mut();
     b.iter(|| {
         for i in 0..count {
-            let _ = focus.get(i as usize);
+            let _ = focus.get(i);
         }
     })
 }

--- a/src/hash/map.rs
+++ b/src/hash/map.rs
@@ -411,7 +411,7 @@ where
     {
         self.root
             .get(hash_key(&*self.hasher, key), 0, key)
-            .map(|&(_, ref v)| v)
+            .map(|(_, v)| v)
     }
 
     /// Get the key/value pair for a key from a hash map.
@@ -437,7 +437,7 @@ where
     {
         self.root
             .get(hash_key(&*self.hasher, key), 0, key)
-            .map(|&(ref k, ref v)| (k, v))
+            .map(|(k, v)| (k, v))
     }
 
     /// Test for the presence of a key in a hash map.
@@ -830,7 +830,7 @@ where
         F: FnOnce(Option<V>) -> Option<V>,
     {
         let pop = self.extract_with_key(&k);
-        match (f(pop.as_ref().map(|&(_, ref v, _)| v.clone())), pop) {
+        match (f(pop.as_ref().map(|(_, v, _)| v.clone())), pop) {
             (None, None) => self.clone(),
             (Some(v), None) => self.update(k, v),
             (None, Some((_, _, m))) => m,
@@ -1712,7 +1712,7 @@ where
     fn index(&self, key: &BK) -> &Self::Output {
         match self.root.get(hash_key(&*self.hasher, key), 0, key) {
             None => panic!("HashMap::index: invalid key"),
-            Some(&(_, ref value)) => value,
+            Some((_, value)) => value,
         }
     }
 }
@@ -2147,7 +2147,7 @@ mod test {
         let pairs = [(1469, 0), (-67, 0)];
         let mut m: collections::HashMap<i16, i16, _> =
             collections::HashMap::with_hasher(BuildHasherDefault::<LolHasher>::default());
-        for &(ref k, ref v) in &pairs {
+        for (k, v) in &pairs {
             m.insert(*k, *v);
         }
         let mut map: HashMap<i16, i16, _> =
@@ -2283,7 +2283,7 @@ mod test {
         fn without(ref pairs in collection::vec((i16::ANY, i16::ANY), 0..100)) {
             let mut m: collections::HashMap<i16, i16, _> =
                 collections::HashMap::with_hasher(BuildHasherDefault::<LolHasher>::default());
-            for &(ref k, ref v) in pairs {
+            for (k, v) in pairs {
                 m.insert(*k, *v);
             }
             let mut map: HashMap<i16, i16, _> = HashMap::with_hasher(BuildHasherDefault::<LolHasher>::default());
@@ -2316,7 +2316,7 @@ mod test {
         fn remove(ref pairs in collection::vec((i16::ANY, i16::ANY), 0..100)) {
             let mut m: collections::HashMap<i16, i16, _> =
                 collections::HashMap::with_hasher(BuildHasherDefault::<LolHasher>::default());
-            for &(ref k, ref v) in pairs {
+            for (k, v) in pairs {
                 m.insert(*k, *v);
             }
             let mut map: HashMap<i16, i16, _> = HashMap::with_hasher(BuildHasherDefault::<LolHasher>::default());

--- a/src/nodes/hamt.rs
+++ b/src/nodes/hamt.rs
@@ -402,12 +402,9 @@ impl<A: HashValue> CollisionNode<A> {
         BK: Eq + ?Sized,
         A::Key: Borrow<BK>,
     {
-        for entry in &self.data {
-            if key == entry.extract_key().borrow() {
-                return Some(entry);
-            }
-        }
-        None
+        self.data
+            .iter()
+            .find(|&entry| key == entry.extract_key().borrow())
     }
 
     fn get_mut<BK>(&mut self, key: &BK) -> Option<&mut A>
@@ -415,12 +412,9 @@ impl<A: HashValue> CollisionNode<A> {
         BK: Eq + ?Sized,
         A::Key: Borrow<BK>,
     {
-        for entry in &mut self.data {
-            if key == entry.extract_key().borrow() {
-                return Some(entry);
-            }
-        }
-        None
+        self.data
+            .iter_mut()
+            .find(|entry| key == entry.extract_key().borrow())
     }
 
     fn insert(&mut self, value: A) -> Option<A> {

--- a/src/ord/map.rs
+++ b/src/ord/map.rs
@@ -450,7 +450,7 @@ where
         BK: Ord + ?Sized,
         K: Borrow<BK>,
     {
-        self.root.lookup(key).map(|&(ref k, ref v)| (k, v))
+        self.root.lookup(key).map(|(k, v)| (k, v))
     }
 
     /// Get the closest smaller entry in a map to a given key
@@ -914,7 +914,7 @@ where
         F: FnOnce(Option<V>) -> Option<V>,
     {
         let pop = self.extract_with_key(&k);
-        match (f(pop.as_ref().map(|&(_, ref v, _)| v.clone())), pop) {
+        match (f(pop.as_ref().map(|(_, v, _)| v.clone())), pop) {
             (None, None) => self.clone(),
             (Some(v), None) => self.update(k, v),
             (None, Some((_, _, m))) => m,
@@ -1829,7 +1829,7 @@ where
     fn index(&self, key: &BK) -> &Self::Output {
         match self.root.lookup(key) {
             None => panic!("OrdMap::index: invalid key"),
-            Some(&(_, ref value)) => value,
+            Some((_, value)) => value,
         }
     }
 }
@@ -2104,7 +2104,7 @@ where
 {
     fn from(m: &'a [(RK, RV)]) -> OrdMap<K, V> {
         m.iter()
-            .map(|&(ref k, ref v)| (k.to_owned(), v.to_owned()))
+            .map(|(k, v)| (k.to_owned(), v.to_owned()))
             .collect()
     }
 }
@@ -2130,7 +2130,7 @@ where
 {
     fn from(m: &'a Vec<(RK, RV)>) -> OrdMap<K, V> {
         m.iter()
-            .map(|&(ref k, ref v)| (k.to_owned(), v.to_owned()))
+            .map(|(k, v)| (k.to_owned(), v.to_owned()))
             .collect()
     }
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -138,7 +138,7 @@ impl<A: Ord + Clone + Serialize> Serialize for OrdSet<A> {
     {
         let mut s = ser.serialize_seq(Some(self.len()))?;
         for i in self.iter() {
-            s.serialize_element(i.deref())?;
+            s.serialize_element(i)?;
         }
         s.end()
     }
@@ -164,7 +164,7 @@ impl<K: Serialize + Ord + Clone, V: Serialize + Clone> Serialize for OrdMap<K, V
     {
         let mut s = ser.serialize_map(Some(self.len()))?;
         for (k, v) in self.iter() {
-            s.serialize_entry(k.deref(), v.deref())?;
+            s.serialize_entry(k, v)?;
         }
         s.end()
     }
@@ -198,7 +198,7 @@ where
     {
         let mut s = ser.serialize_map(Some(self.len()))?;
         for (k, v) in self.iter() {
-            s.serialize_entry(k.deref(), v.deref())?;
+            s.serialize_entry(k, v)?;
         }
         s.end()
     }
@@ -224,7 +224,7 @@ impl<A: Serialize + Hash + Eq + Clone, S: BuildHasher + Default> Serialize for H
     {
         let mut s = ser.serialize_seq(Some(self.len()))?;
         for i in self.iter() {
-            s.serialize_element(i.deref())?;
+            s.serialize_element(i)?;
         }
         s.end()
     }
@@ -248,7 +248,7 @@ impl<A: Clone + Serialize> Serialize for Vector<A> {
     {
         let mut s = ser.serialize_seq(Some(self.len()))?;
         for i in self.iter() {
-            s.serialize_element(i.deref())?;
+            s.serialize_element(i)?;
         }
         s.end()
     }

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -2822,7 +2822,7 @@ mod test {
             let output: Vector<_> = input.leaves().flatten().cloned().collect();
             assert_eq!(input, &output);
             let rev_in: Vector<_> = input.iter().rev().cloned().collect();
-            let rev_out: Vector<_> = input.leaves().rev().map(|c| c.iter().rev()).flatten().cloned().collect();
+            let rev_out: Vector<_> = input.leaves().rev().flat_map(|c| c.iter().rev()).cloned().collect();
             assert_eq!(rev_in, rev_out);
         }
 
@@ -2833,7 +2833,7 @@ mod test {
             let output: Vector<_> = input.leaves_mut().flatten().map(|v| *v).collect();
             assert_eq!(input, output);
             let rev_in: Vector<_> = input.iter().rev().cloned().collect();
-            let rev_out: Vector<_> = input.leaves_mut().rev().map(|c| c.iter().rev()).flatten().cloned().collect();
+            let rev_out: Vector<_> = input.leaves_mut().rev().flat_map(|c| c.iter().rev()).cloned().collect();
             assert_eq!(rev_in, rev_out);
         }
 


### PR DESCRIPTION
Automated with `cargo +nightly clippy --fix`. Undid two invalid changes by hand (cc https://github.com/rust-lang/rust-clippy/issues/11341).