### PR TITLE
hashmap: Remove unnecessary trait bounds

### DIFF
--- a/src/hash/map.rs
+++ b/src/hash/map.rs
@@ -367,7 +367,6 @@ where
 {
     fn test_eq(&self, other: &Self) -> bool
     where
-        K: Hash + Eq,
         V: PartialEq,
     {
         if self.len() != other.len() {
@@ -1736,9 +1735,8 @@ where
 #[cfg(not(has_specialisation))]
 impl<K, V, S> Debug for HashMap<K, V, S>
 where
-    K: Hash + Eq + Debug,
+    K: Debug,
     V: Debug,
-    S: BuildHasher,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         let mut d = f.debug_map();
@@ -1752,9 +1750,8 @@ where
 #[cfg(has_specialisation)]
 impl<K, V, S> Debug for HashMap<K, V, S>
 where
-    K: Hash + Eq + Debug,
+    K: Debug,
     V: Debug,
-    S: BuildHasher,
 {
     default fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         let mut d = f.debug_map();
@@ -1768,9 +1765,8 @@ where
 #[cfg(has_specialisation)]
 impl<K, V, S> Debug for HashMap<K, V, S>
 where
-    K: Hash + Eq + Ord + Debug,
+    K: Ord + Debug,
     V: Debug,
-    S: BuildHasher,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         let mut keys = collections::BTreeSet::new();
@@ -1920,11 +1916,7 @@ impl<'a, K, V> ExactSizeIterator for Values<'a, K, V> {}
 
 impl<'a, K, V> FusedIterator for Values<'a, K, V> {}
 
-impl<'a, K, V, S> IntoIterator for &'a HashMap<K, V, S>
-where
-    K: Hash + Eq,
-    S: BuildHasher,
-{
+impl<'a, K, V, S> IntoIterator for &'a HashMap<K, V, S> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;
 

--- a/src/nodes/hamt.rs
+++ b/src/nodes/hamt.rs
@@ -632,10 +632,7 @@ impl<'a, A> FusedIterator for IterMut<'a, A> where A: Clone + 'a {}
 
 // Consuming iterator
 
-pub(crate) struct Drain<A>
-where
-    A: HashValue,
-{
+pub(crate) struct Drain<A> {
     count: usize,
     pool: Pool<Node<A>>,
     stack: Vec<PoolRef<Node<A>>>,
@@ -643,10 +640,7 @@ where
     collision: Option<CollisionNode<A>>,
 }
 
-impl<A> Drain<A>
-where
-    A: HashValue,
-{
+impl<A> Drain<A> {
     pub(crate) fn new(pool: &Pool<Node<A>>, root: PoolRef<Node<A>>, size: usize) -> Self {
         Drain {
             count: size,
@@ -660,7 +654,7 @@ where
 
 impl<A> Iterator for Drain<A>
 where
-    A: HashValue + Clone,
+    A: Clone,
 {
     type Item = (A, HashBits);
 
@@ -707,11 +701,11 @@ where
     }
 }
 
-impl<A: HashValue> ExactSizeIterator for Drain<A> where A: Clone {}
+impl<A> ExactSizeIterator for Drain<A> where A: Clone {}
 
-impl<A: HashValue> FusedIterator for Drain<A> where A: Clone {}
+impl<A> FusedIterator for Drain<A> where A: Clone {}
 
-impl<A: HashValue + fmt::Debug> fmt::Debug for Node<A> {
+impl<A: fmt::Debug> fmt::Debug for Node<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "Node[ ")?;
         for i in self.data.indices() {


### PR DESCRIPTION
Most importantly, the Debug implementation no longer requires any bounds other than K: Debug and V: Debug, allowing users to derive Debug for structs that are generic over key and/or value of an internal HashMap.