### PR TITLE
Don't panic in truncate if len > self.len()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- `Vector::truncate` no longer panics if the `len` argument is larger than the
+  vector's length (instead it does nothing)
+
 ## [2.0.2] - 2023-08-19
 
 ### Changed

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1358,13 +1358,14 @@ impl<A: Clone> Vector<A> {
     /// Truncate a vector to the given size.
     ///
     /// Discards all elements in the vector beyond the given length.
-    ///
-    /// Panics if the new length is greater than the current length.
+    /// Does nothing if `len` is greater or equal to the length of the vector.
     ///
     /// Time: O(log n)
     pub fn truncate(&mut self, len: usize) {
-        // FIXME can be made more efficient by dropping the unwanted side without constructing it
-        let _ = self.split_off(len);
+        if len < self.len() {
+            // FIXME can be made more efficient by dropping the unwanted side without constructing it
+            let _ = self.split_off(len);
+        }
     }
 
     /// Extract a slice from a vector.


### PR DESCRIPTION
Closes #66. I wanted to make the impl smarter, but `split_off`, which `truncate` currently uses as its implementation, is quite large and I don't understand im(bl)'s internals well enough to make this a quick PR. Will look into adding `InlineArray::truncate` as a first step though.