### PR TITLE
Remove unnecessary Clone bounds on Serialize impls

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -14,21 +14,13 @@ use crate::ordmap::OrdMap;
 use crate::ordset::OrdSet;
 use crate::vector::Vector;
 
-struct SeqVisitor<'de, S, A>
-where
-    S: From<Vec<A>>,
-    A: Deserialize<'de>,
-{
+struct SeqVisitor<'de, S, A> {
     phantom_s: PhantomData<S>,
     phantom_a: PhantomData<A>,
     phantom_lifetime: PhantomData<&'de ()>,
 }
 
-impl<'de, S, A> SeqVisitor<'de, S, A>
-where
-    S: From<Vec<A>>,
-    A: Deserialize<'de>,
-{
+impl<'de, S, A> SeqVisitor<'de, S, A> {
     pub(crate) fn new() -> SeqVisitor<'de, S, A> {
         SeqVisitor {
             phantom_s: PhantomData,
@@ -64,24 +56,14 @@ where
     }
 }
 
-struct MapVisitor<'de, S, K, V>
-where
-    S: From<Vec<(K, V)>>,
-    K: Deserialize<'de>,
-    V: Deserialize<'de>,
-{
+struct MapVisitor<'de, S, K, V> {
     phantom_s: PhantomData<S>,
     phantom_k: PhantomData<K>,
     phantom_v: PhantomData<V>,
     phantom_lifetime: PhantomData<&'de ()>,
 }
 
-impl<'de, S, K, V> MapVisitor<'de, S, K, V>
-where
-    S: From<Vec<(K, V)>>,
-    K: Deserialize<'de>,
-    V: Deserialize<'de>,
-{
+impl<'de, S, K, V> MapVisitor<'de, S, K, V> {
     pub(crate) fn new() -> MapVisitor<'de, S, K, V> {
         MapVisitor {
             phantom_s: PhantomData,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -112,7 +112,7 @@ impl<'de, A: Deserialize<'de> + Ord + Clone> Deserialize<'de> for OrdSet<A> {
     }
 }
 
-impl<A: Ord + Clone + Serialize> Serialize for OrdSet<A> {
+impl<A: Ord + Serialize> Serialize for OrdSet<A> {
     fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -138,7 +138,7 @@ impl<'de, K: Deserialize<'de> + Ord + Clone, V: Deserialize<'de> + Clone> Deseri
     }
 }
 
-impl<K: Serialize + Ord + Clone, V: Serialize + Clone> Serialize for OrdMap<K, V> {
+impl<K: Serialize + Ord, V: Serialize> Serialize for OrdMap<K, V> {
     fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -169,8 +169,8 @@ where
 
 impl<K, V, S> Serialize for HashMap<K, V, S>
 where
-    K: Serialize + Hash + Eq + Clone,
-    V: Serialize + Clone,
+    K: Serialize + Hash + Eq,
+    V: Serialize,
     S: BuildHasher + Default,
 {
     fn serialize<Ser>(&self, ser: Ser) -> Result<Ser::Ok, Ser::Error>
@@ -198,7 +198,7 @@ impl<'de, A: Deserialize<'de> + Hash + Eq + Clone, S: BuildHasher + Default> Des
     }
 }
 
-impl<A: Serialize + Hash + Eq + Clone, S: BuildHasher + Default> Serialize for HashSet<A, S> {
+impl<A: Serialize + Hash + Eq, S: BuildHasher + Default> Serialize for HashSet<A, S> {
     fn serialize<Ser>(&self, ser: Ser) -> Result<Ser::Ok, Ser::Error>
     where
         Ser: Serializer,
@@ -222,7 +222,7 @@ impl<'de, A: Clone + Deserialize<'de>> Deserialize<'de> for Vector<A> {
     }
 }
 
-impl<A: Clone + Serialize> Serialize for Vector<A> {
+impl<A: Serialize> Serialize for Vector<A> {
     fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,


### PR DESCRIPTION
The impls are not really useful for non-`Clone` types, but this allows deriving `Serialize` for types with fields of type `imbl::Container<GenericParameter>` without `#[serde(bound)]` overrides for the generates impls.