### PR TITLE
Add support for using `triomphe::Arc` behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ bitmaps = "2"
 sized-chunks = "0.6.4"
 rand_core = "0.6.3"
 rand_xoshiro = "0.6"
+triomphe = { version = "0.1.11", optional = true }
 quickcheck = { version = "1.0", optional = true }
 proptest = { version = "1.0", optional = true }
 serde = { version = "1", optional = true }

--- a/src/fakepool.rs
+++ b/src/fakepool.rs
@@ -206,3 +206,92 @@ where
         self.0.fmt(f)
     }
 }
+
+// Triomphe Arc
+#[cfg(feature = "triomphe")]
+pub(crate) mod triomphe {
+    use super::*;
+
+    #[derive(Default)]
+    pub(crate) struct Arc<A>(::triomphe::Arc<A>);
+
+    impl<A> Arc<A> {
+        #[inline(always)]
+        pub(crate) fn default(_pool: &Pool<A>) -> Self
+        where
+            A: PoolDefault,
+        {
+            Self(Default::default())
+        }
+
+        #[inline(always)]
+        pub(crate) fn new(_pool: &Pool<A>, value: A) -> Self {
+            Self(::triomphe::Arc::new(value))
+        }
+
+        #[inline(always)]
+        pub(crate) fn clone_from(_pool: &Pool<A>, value: &A) -> Self
+        where
+            A: PoolClone,
+        {
+            Self(::triomphe::Arc::new(value.clone()))
+        }
+
+        #[inline(always)]
+        pub(crate) fn make_mut<'a>(_pool: &Pool<A>, this: &'a mut Self) -> &'a mut A
+        where
+            A: PoolClone,
+        {
+            ::triomphe::Arc::make_mut(&mut this.0)
+        }
+
+        #[inline(always)]
+        pub(crate) fn ptr_eq(left: &Self, right: &Self) -> bool {
+            ::triomphe::Arc::ptr_eq(&left.0, &right.0)
+        }
+
+        pub(crate) fn unwrap_or_clone(this: Self) -> A
+        where
+            A: PoolClone,
+        {
+            ::triomphe::Arc::try_unwrap(this.0).unwrap_or_else(|r| (*r).clone())
+        }
+    }
+
+    impl<A> Clone for Arc<A> {
+        #[inline(always)]
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+
+    impl<A> Deref for Arc<A> {
+        type Target = A;
+        #[inline(always)]
+        fn deref(&self) -> &Self::Target {
+            self.0.deref()
+        }
+    }
+
+    impl<A> PartialEq for Arc<A>
+    where
+        A: PartialEq,
+    {
+        #[inline(always)]
+        fn eq(&self, other: &Self) -> bool {
+            **self == **other
+        }
+    }
+
+    impl<A> Eq for Arc<A> where A: Eq {}
+
+    impl<A> std::fmt::Debug for Arc<A>
+    where
+        A: std::fmt::Debug,
+    {
+        #[inline(always)]
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            self.0.fmt(f)
+        }
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,10 +13,18 @@ pub(crate) use refpool::{PoolClone, PoolDefault};
 // The `Ref` type is an alias for either `Rc` or `Arc`, user's choice.
 // FIXME: we have temporarily disabled `Rc`, so this is always `Arc`.
 // `Arc` without refpool
-pub(crate) use crate::fakepool::{Arc as PoolRef, Pool, PoolClone, PoolDefault};
+pub(crate) use crate::fakepool::{Pool, PoolClone, PoolDefault};
 
+#[cfg(feature = "triomphe")]
+pub(crate) type Ref<A> = ::triomphe::Arc<A>;
 // `Ref` == `Arc` when threadsafe
+#[cfg(not(feature = "triomphe"))]
 pub(crate) type Ref<A> = std::sync::Arc<A>;
+
+#[cfg(feature = "triomphe")]
+pub(crate) use crate::fakepool::triomphe::Arc as PoolRef;
+#[cfg(not(feature = "triomphe"))]
+pub(crate) use crate::fakepool::Arc as PoolRef;
 
 pub(crate) fn clone_ref<A>(r: Ref<A>) -> A
 where


### PR DESCRIPTION
Add support for using `triomphe::Arc` behind a feature flag with the same name.

[`triomphe::Arc`](https://docs.rs/triomphe/0.1.11/triomphe/struct.Arc.html) has no weak references, so it has simpler/faster copy-on-write methods like `make_mut` and `try_unwrap`.

On my x64 box the improvements are hard to detect (single digits %) but it can only get faster with contention and/or weaker memory models (e.g. arm64).