### PR TITLE
Speedup hashmap by speeding up node creation

### DIFF
--- a/src/fakepool.rs
+++ b/src/fakepool.rs
@@ -4,7 +4,9 @@
 
 #![allow(dead_code)]
 
+use std::cell::UnsafeCell;
 use std::marker::PhantomData;
+use std::mem::MaybeUninit;
 use std::ops::Deref;
 use std::rc::Rc as RRc;
 use std::sync::Arc as RArc;
@@ -54,6 +56,11 @@ impl<A> Rc<A> {
     #[inline(always)]
     pub(crate) fn new(_pool: &Pool<A>, value: A) -> Self {
         Rc(RRc::new(value))
+    }
+
+    #[inline(always)]
+    pub(crate) fn new_uninit(_pool: &Pool<A>) -> Rc<UnsafeCell<MaybeUninit<A>>> {
+        Rc(RRc::new(UnsafeCell::new(MaybeUninit::uninit())))
     }
 
     #[inline(always)]
@@ -142,6 +149,11 @@ impl<A> Arc<A> {
     }
 
     #[inline(always)]
+    pub(crate) fn new_uninit(_pool: &Pool<A>) -> Arc<UnsafeCell<MaybeUninit<A>>> {
+        Arc(RArc::new(UnsafeCell::new(MaybeUninit::uninit())))
+    }
+
+    #[inline(always)]
     pub(crate) fn clone_from(_pool: &Pool<A>, value: &A) -> Self
     where
         A: PoolClone,
@@ -210,6 +222,8 @@ where
 // Triomphe Arc
 #[cfg(feature = "triomphe")]
 pub(crate) mod triomphe {
+    use std::cell::UnsafeCell;
+
     use super::*;
 
     #[derive(Default)]
@@ -227,6 +241,11 @@ pub(crate) mod triomphe {
         #[inline(always)]
         pub(crate) fn new(_pool: &Pool<A>, value: A) -> Self {
             Self(::triomphe::Arc::new(value))
+        }
+
+        #[inline(always)]
+        pub(crate) fn new_uninit(_pool: &Pool<A>) -> Arc<UnsafeCell<MaybeUninit<A>>> {
+            Arc(::triomphe::Arc::new(UnsafeCell::new(MaybeUninit::uninit())))
         }
 
         #[inline(always)]

--- a/src/hash/set.rs
+++ b/src/hash/set.rs
@@ -26,8 +26,7 @@ use std::collections::hash_map::RandomState;
 use std::collections::{self, BTreeSet};
 use std::fmt::{Debug, Error, Formatter};
 use std::hash::{BuildHasher, Hash};
-use std::iter::FusedIterator;
-use std::iter::{FromIterator, IntoIterator, Sum};
+use std::iter::{FromIterator, FusedIterator, Sum};
 use std::ops::{Add, Deref, Mul};
 
 use crate::nodes::hamt::{hash_key, Drain as NodeDrain, HashValue, Iter as NodeIter, Node};

--- a/src/ord/map.rs
+++ b/src/ord/map.rs
@@ -22,7 +22,7 @@ use std::cmp::Ordering;
 use std::collections;
 use std::fmt::{Debug, Error, Formatter};
 use std::hash::{BuildHasher, Hash, Hasher};
-use std::iter::{FromIterator, Iterator, Sum};
+use std::iter::{FromIterator, Sum};
 use std::mem;
 use std::ops::{Add, Index, IndexMut, RangeBounds};
 

--- a/src/ord/set.rs
+++ b/src/ord/set.rs
@@ -20,7 +20,7 @@ use std::cmp::Ordering;
 use std::collections;
 use std::fmt::{Debug, Error, Formatter};
 use std::hash::{BuildHasher, Hash, Hasher};
-use std::iter::{FromIterator, IntoIterator, Sum};
+use std::iter::{FromIterator, Sum};
 use std::ops::{Add, Deref, Mul, RangeBounds};
 
 use crate::hashset::HashSet;


### PR DESCRIPTION
During profiling, I noticed a lot of time was being spent in memcopy. I tracked it down to less than ideal Node initialization. I ended up utilizing a combination of `UnsafeCell` and `MaybeUninit` to avoid utilizing unstable APIs.


These results are for small pairs `u64, u64` but the delta increases with larger items.

Before

```
test hashmap_insert_mut_10     ... bench:         407 ns/iter (+/- 5)
test hashmap_insert_mut_100    ... bench:       7,380 ns/iter (+/- 122)
test hashmap_insert_mut_1000   ... bench:      81,006 ns/iter (+/- 1,841)
test hashmap_insert_mut_10000  ... bench:     879,453 ns/iter (+/- 29,964)
```

After

```
test hashmap_insert_mut_10     ... bench:         353 ns/iter (+/- 7)
test hashmap_insert_mut_100    ... bench:       5,844 ns/iter (+/- 87)
test hashmap_insert_mut_1000   ... bench:      63,217 ns/iter (+/- 7,667)
test hashmap_insert_mut_10000  ... bench:     738,824 ns/iter (+/- 28,214)
```