### PR TITLE
Fix bounds checks on Focus::narrow and split_at

### DIFF
--- a/src/vector/focus.rs
+++ b/src/vector/focus.rs
@@ -194,7 +194,7 @@ where
         R: RangeBounds<usize>,
     {
         let r = to_range(&range, self.len());
-        if r.start >= r.end || r.start >= self.len() {
+        if r.start > r.end || r.end > self.len() {
             panic!("vector::Focus::narrow: range out of bounds");
         }
         match self {
@@ -232,7 +232,7 @@ where
     /// [slice::split_at]: https://doc.rust-lang.org/std/primitive.slice.html#method.split_at
     /// [Vector::split_at]: enum.Vector.html#method.split_at
     pub fn split_at(self, index: usize) -> (Self, Self) {
-        if index >= self.len() {
+        if index > self.len() {
             panic!("vector::Focus::split_at: index out of bounds");
         }
         match self {


### PR DESCRIPTION
I noticed that these methods were more restrictive than necessary, as compared to subslicing a slice (or even Vector::slice), making it hard (though not impossible) to end up with an empty Focus. Additionally `narrow()` allowed its end index to go past `len()` which could lead to other problems.

I added some tests for these methods too.