### PR TITLE
Run actions-rs/toolchain with override: true

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -36,6 +37,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
+          override: true
       - name: Run tests
         run: |
           cargo test --all-features
@@ -49,6 +51,7 @@ jobs:
         with:
           toolchain: stable
           components: clippy
+          override: true
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is definitely going to fail right now because the crate won't build with 1.51