### PR TITLE
Less warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,8 +21,3 @@ pub(crate) const ORD_CHUNK_SIZE: usize = 64;
 pub(crate) const HASH_LEVEL_SIZE: usize = 2;
 #[cfg(not(feature = "small-chunks"))]
 pub(crate) const HASH_LEVEL_SIZE: usize = 5;
-
-/// The size of per-instance memory pools if the `pool` feature is enabled.
-/// This is set to 0, meaning you have to opt in to using a pool by constructing
-/// with eg. `Vector::with_pool(pool)` even if the `pool` feature is enabled.
-pub(crate) const POOL_SIZE: usize = 0;

--- a/src/hash/set.rs
+++ b/src/hash/set.rs
@@ -167,18 +167,6 @@ impl<A, S, P: SharedPointerKind> GenericHashSet<A, S, P> {
         Self::default()
     }
 
-    /// Construct an empty set using a specific memory pool.
-    #[cfg(feature = "pool")]
-    #[must_use]
-    pub fn with_pool(pool: &HashSetPool<A>) -> Self {
-        Self {
-            pool: pool.clone(),
-            hasher: Default::default(),
-            size: 0,
-            root: SharedPointer::default(),
-        }
-    }
-
     /// Test whether a set is empty.
     ///
     /// Time: O(1)
@@ -231,15 +219,6 @@ impl<A, S, P: SharedPointerKind> GenericHashSet<A, S, P> {
         std::ptr::eq(self, other) || SharedPointer::ptr_eq(&self.root, &other.root)
     }
 
-    /// Get a reference to the memory pool used by this set.
-    ///
-    /// Note that if you didn't specifically construct it with a pool, you'll
-    /// get back a reference to a pool of size 0.
-    #[cfg(feature = "pool")]
-    pub fn pool(&self) -> &HashSetPool<A> {
-        &self.pool
-    }
-
     /// Construct an empty hash set using the provided hasher.
     #[inline]
     #[must_use]
@@ -252,23 +231,6 @@ impl<A, S, P: SharedPointerKind> GenericHashSet<A, S, P> {
         GenericHashSet {
             size: 0,
             pool,
-            root,
-            hasher: From::from(hasher),
-        }
-    }
-
-    /// Construct an empty hash set using the provided memory pool and hasher.
-    #[cfg(feature = "pool")]
-    #[inline]
-    #[must_use]
-    pub fn with_pool_hasher<RS>(pool: &HashSetPool<A>, hasher: RS) -> Self
-    where
-        SharedPointer<S>: From<RS>,
-    {
-        let root = SharedPointer::default();
-        GenericHashSet {
-            size: 0,
-            pool: pool.clone(),
             root,
             hasher: From::from(hasher),
         }
@@ -793,34 +755,9 @@ where
     }
 }
 
-#[cfg(not(has_specialisation))]
 impl<A, S, P> Debug for GenericHashSet<A, S, P>
 where
     A: Hash + Eq + Debug,
-    S: BuildHasher,
-    P: SharedPointerKind,
-{
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        f.debug_set().entries(self.iter()).finish()
-    }
-}
-
-#[cfg(has_specialisation)]
-impl<A, S, P> Debug for GenericHashSet<A, S, P>
-where
-    A: Hash + Eq + Debug,
-    S: BuildHasher,
-    P: SharedPointerKind,
-{
-    default fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        f.debug_set().entries(self.iter()).finish()
-    }
-}
-
-#[cfg(has_specialisation)]
-impl<A, S, P> Debug for GenericHashSet<A, S, P>
-where
-    A: Hash + Eq + Debug + Ord,
     S: BuildHasher,
     P: SharedPointerKind,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,8 +378,6 @@ pub mod arbitrary;
 #[doc(hidden)]
 pub mod quickcheck;
 
-mod fakepool;
-
 pub mod shared_ptr;
 
 pub use crate::hashmap::{GenericHashMap, HashMap};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,8 +334,7 @@
 #![forbid(rust_2018_idioms)]
 #![deny(nonstandard_style)]
 #![warn(unreachable_pub, missing_docs)]
-#![cfg_attr(has_specialisation, feature(specialization))]
-#![cfg_attr(not(feature = "pool"), deny(unsafe_code))]
+#![deny(unsafe_code)]
 
 #[cfg(test)]
 #[macro_use]
@@ -379,13 +378,7 @@ pub mod arbitrary;
 #[doc(hidden)]
 pub mod quickcheck;
 
-#[cfg(not(feature = "pool"))]
 mod fakepool;
-
-#[cfg(feature = "pool")]
-compile_error!(
-    "The `pool` feature is not threadsafe but you've enabled it on a threadsafe version of `imbl`."
-);
 
 pub mod shared_ptr;
 

--- a/src/nodes/hamt.rs
+++ b/src/nodes/hamt.rs
@@ -14,7 +14,7 @@ use archery::{SharedPointer, SharedPointerKind};
 use bitmaps::{Bits, BitsImpl};
 use imbl_sized_chunks::sparse_chunk::{Iter as ChunkIter, IterMut as ChunkIterMut, SparseChunk};
 
-use crate::util::{clone_ref, Pool, PoolClone, PoolDefault};
+use crate::util::{clone_ref, Pool};
 
 pub(crate) use crate::config::HASH_LEVEL_SIZE as HASH_SHIFT;
 pub(crate) const HASH_WIDTH: usize = 2_usize.pow(HASH_SHIFT as u32);
@@ -48,36 +48,6 @@ impl<A: Clone, P: SharedPointerKind> Clone for Node<A, P> {
         Self {
             data: self.data.clone(),
         }
-    }
-}
-
-impl<A, P: SharedPointerKind> PoolDefault for Node<A, P> {
-    #[cfg(feature = "pool")]
-    unsafe fn default_uninit(target: &mut mem::MaybeUninit<Self>) {
-        SparseChunk::default_uninit(
-            target
-                .as_mut_ptr()
-                .cast::<mem::MaybeUninit<SparseChunk<Entry<A>, HASH_WIDTH>>>()
-                .as_mut()
-                .unwrap(),
-        )
-    }
-}
-
-impl<A, P> PoolClone for Node<A, P>
-where
-    A: Clone,
-    P: SharedPointerKind + Clone,
-{
-    #[cfg(feature = "pool")]
-    unsafe fn clone_uninit(&self, target: &mut mem::MaybeUninit<Self>) {
-        self.data.clone_uninit(
-            target
-                .as_mut_ptr()
-                .cast::<mem::MaybeUninit<SparseChunk<Entry<A>, HASH_WIDTH>>>()
-                .as_mut()
-                .unwrap(),
-        )
     }
 }
 

--- a/src/nodes/hamt.rs
+++ b/src/nodes/hamt.rs
@@ -14,7 +14,7 @@ use archery::{SharedPointer, SharedPointerKind};
 use bitmaps::{Bits, BitsImpl};
 use imbl_sized_chunks::sparse_chunk::{Iter as ChunkIter, IterMut as ChunkIterMut, SparseChunk};
 
-use crate::util::{clone_ref, Pool};
+use crate::util::clone_ref;
 
 pub(crate) use crate::config::HASH_LEVEL_SIZE as HASH_SHIFT;
 pub(crate) const HASH_WIDTH: usize = 2_usize.pow(HASH_SHIFT as u32);
@@ -109,7 +109,7 @@ impl<A, P: SharedPointerKind> Node<A, P> {
     /// Special constructor to allow initializing Nodes w/o incurring multiple memory copies.
     /// These copies really slow things down once Node crosses a certain size threshold and copies become calls to memcopy.
     #[inline]
-    fn with(_pool: &Pool<Self>, with: impl FnOnce(&mut Self)) -> SharedPointer<Self, P> {
+    fn with(with: impl FnOnce(&mut Self)) -> SharedPointer<Self, P> {
         let result: UnsafeCell<mem::MaybeUninit<Node<A, P>>> =
             UnsafeCell::new(mem::MaybeUninit::uninit());
         // Seems there's no need to use unsafe?
@@ -133,21 +133,20 @@ impl<A, P: SharedPointerKind> Node<A, P> {
     }
 
     #[inline]
-    fn unit(pool: &Pool<Node<A, P>>, index: usize, value: Entry<A, P>) -> SharedPointer<Self, P> {
-        Self::with(pool, |this| {
+    fn unit(index: usize, value: Entry<A, P>) -> SharedPointer<Self, P> {
+        Self::with(|this| {
             this.data.insert(index, value);
         })
     }
 
     #[inline]
     fn pair(
-        pool: &Pool<Node<A, P>>,
         index1: usize,
         value1: Entry<A, P>,
         index2: usize,
         value2: Entry<A, P>,
     ) -> SharedPointer<Self, P> {
-        Self::with(pool, |this| {
+        Self::with(|this| {
             this.data.insert(index1, value1);
             this.data.insert(index2, value2);
         })
@@ -155,11 +154,10 @@ impl<A, P: SharedPointerKind> Node<A, P> {
 
     #[inline]
     pub(crate) fn single_child(
-        pool: &Pool<Node<A, P>>,
         index: usize,
         node: SharedPointer<Self, P>,
     ) -> SharedPointer<Self, P> {
-        Self::unit(pool, index, Entry::Node(node))
+        Self::unit(index, Entry::Node(node))
     }
 
     fn pop(&mut self) -> Entry<A, P> {
@@ -169,7 +167,6 @@ impl<A, P: SharedPointerKind> Node<A, P> {
 
 impl<A: HashValue, P: SharedPointerKind> Node<A, P> {
     fn merge_values(
-        pool: &Pool<Node<A, P>>,
         value1: A,
         hash1: HashBits,
         value2: A,
@@ -181,7 +178,6 @@ impl<A: HashValue, P: SharedPointerKind> Node<A, P> {
         if index1 != index2 {
             // Both values fit on the same level.
             Node::pair(
-                pool,
                 index1,
                 Entry::Value(value1, hash1),
                 index2,
@@ -190,14 +186,13 @@ impl<A: HashValue, P: SharedPointerKind> Node<A, P> {
         } else if shift + HASH_SHIFT >= HASH_WIDTH {
             // If we're at the bottom, we've got a collision.
             Node::unit(
-                pool,
                 index1,
                 Entry::from(CollisionNode::new(hash1, value1, value2)),
             )
         } else {
             // Pass the values down a level.
-            let node = Node::merge_values(pool, value1, hash1, value2, hash2, shift + HASH_SHIFT);
-            Node::single_child(pool, index1, node)
+            let node = Node::merge_values(value1, hash1, value2, hash2, shift + HASH_SHIFT);
+            Node::single_child(index1, node)
         }
     }
 
@@ -224,13 +219,7 @@ impl<A: HashValue, P: SharedPointerKind> Node<A, P> {
         }
     }
 
-    pub(crate) fn get_mut<BK>(
-        &mut self,
-        pool: &Pool<Node<A, P>>,
-        hash: HashBits,
-        shift: usize,
-        key: &BK,
-    ) -> Option<&mut A>
+    pub(crate) fn get_mut<BK>(&mut self, hash: HashBits, shift: usize, key: &BK) -> Option<&mut A>
     where
         A: Clone,
         BK: Eq + ?Sized,
@@ -252,7 +241,7 @@ impl<A: HashValue, P: SharedPointerKind> Node<A, P> {
                 }
                 Entry::Node(ref mut child_ref) => {
                     let child = SharedPointer::make_mut(child_ref);
-                    child.get_mut(pool, hash, shift + HASH_SHIFT, key)
+                    child.get_mut(hash, shift + HASH_SHIFT, key)
                 }
             }
         } else {
@@ -260,13 +249,7 @@ impl<A: HashValue, P: SharedPointerKind> Node<A, P> {
         }
     }
 
-    pub(crate) fn insert(
-        &mut self,
-        pool: &Pool<Node<A, P>>,
-        hash: HashBits,
-        shift: usize,
-        value: A,
-    ) -> Option<A>
+    pub(crate) fn insert(&mut self, hash: HashBits, shift: usize, value: A) -> Option<A>
     where
         A: Clone,
     {
@@ -293,7 +276,7 @@ impl<A: HashValue, P: SharedPointerKind> Node<A, P> {
                 Entry::Node(ref mut child_ref) => {
                     // Child node
                     let child = SharedPointer::make_mut(child_ref);
-                    return child.insert(pool, hash, shift + HASH_SHIFT, value);
+                    return child.insert(hash, shift + HASH_SHIFT, value);
                 }
             }
             #[allow(unsafe_code)]
@@ -307,14 +290,8 @@ impl<A: HashValue, P: SharedPointerKind> Node<A, P> {
                     let coll = CollisionNode::new(hash, old_entry.unwrap_value(), value);
                     unsafe { ptr::write(entry, Entry::from(coll)) };
                 } else if let Entry::Value(old_value, old_hash) = old_entry {
-                    let node = Node::merge_values(
-                        pool,
-                        old_value,
-                        old_hash,
-                        value,
-                        hash,
-                        shift + HASH_SHIFT,
-                    );
+                    let node =
+                        Node::merge_values(old_value, old_hash, value, hash, shift + HASH_SHIFT);
                     unsafe { ptr::write(entry, Entry::Node(node)) };
                 } else {
                     unreachable!()
@@ -330,13 +307,7 @@ impl<A: HashValue, P: SharedPointerKind> Node<A, P> {
             .map(Entry::unwrap_value)
     }
 
-    pub(crate) fn remove<BK>(
-        &mut self,
-        pool: &Pool<Node<A, P>>,
-        hash: HashBits,
-        shift: usize,
-        key: &BK,
-    ) -> Option<A>
+    pub(crate) fn remove<BK>(&mut self, hash: HashBits, shift: usize, key: &BK) -> Option<A>
     where
         A: Clone,
         BK: Eq + ?Sized,
@@ -364,7 +335,7 @@ impl<A: HashValue, P: SharedPointerKind> Node<A, P> {
                 }
                 Entry::Node(ref mut child_ref) => {
                     let child = SharedPointer::make_mut(child_ref);
-                    match child.remove(pool, hash, shift + HASH_SHIFT, key) {
+                    match child.remove(hash, shift + HASH_SHIFT, key) {
                         None => {
                             return None;
                         }
@@ -547,7 +518,6 @@ impl<'a, A, P: SharedPointerKind> FusedIterator for Iter<'a, A, P> where A: 'a {
 
 pub(crate) struct IterMut<'a, A, P: SharedPointerKind> {
     count: usize,
-    _pool: Pool<Node<A, P>>,
     stack: Vec<ChunkIterMut<'a, Entry<A, P>, HASH_WIDTH>>,
     collision: Option<(HashBits, SliceIterMut<'a, A>)>,
 }
@@ -557,10 +527,9 @@ where
     A: 'a,
     P: SharedPointerKind,
 {
-    pub(crate) fn new(pool: &Pool<Node<A, P>>, root: &'a mut Node<A, P>, size: usize) -> Self {
+    pub(crate) fn new(root: &'a mut Node<A, P>, size: usize) -> Self {
         let mut result = IterMut {
             count: size,
-            _pool: pool.clone(),
             stack: Vec::with_capacity((HASH_WIDTH / HASH_SHIFT) + 1),
             collision: None,
         };
@@ -625,20 +594,14 @@ impl<'a, A, P: SharedPointerKind> FusedIterator for IterMut<'a, A, P> where A: C
 
 pub(crate) struct Drain<A, P: SharedPointerKind> {
     count: usize,
-    _pool: Pool<Node<A, P>>,
     stack: Vec<SharedPointer<Node<A, P>, P>>,
     collision: Option<CollisionNode<A>>,
 }
 
 impl<A, P: SharedPointerKind> Drain<A, P> {
-    pub(crate) fn new(
-        pool: &Pool<Node<A, P>>,
-        root: SharedPointer<Node<A, P>, P>,
-        size: usize,
-    ) -> Self {
+    pub(crate) fn new(root: SharedPointer<Node<A, P>, P>, size: usize) -> Self {
         let mut result = Drain {
             count: size,
-            _pool: pool.clone(),
             stack: Vec::with_capacity((HASH_WIDTH / HASH_SHIFT) + 1),
             collision: None,
         };

--- a/src/ord/set.rs
+++ b/src/ord/set.rs
@@ -31,7 +31,6 @@ use crate::nodes::btree::{
     Iter as NodeIter, Node, Remove,
 };
 use crate::shared_ptr::DefaultSharedPtr;
-use crate::util::Pool;
 
 pub use crate::nodes::btree::DiffItem;
 
@@ -106,8 +105,6 @@ impl<A: Ord> BTreeValue for Value<A> {
     }
 }
 
-def_pool!(OrdSetPool<A>, Node<Value<A>, P>);
-
 /// Type alias for [`GenericOrdSet`] that uses [`DefaultSharedPtr`] as the pointer type.
 ///
 /// [GenericOrdSet]: ./struct.GenericOrdSet.html
@@ -128,7 +125,6 @@ pub type OrdSet<A> = GenericOrdSet<A, DefaultSharedPtr>;
 /// [1]: https://en.wikipedia.org/wiki/B-tree
 pub struct GenericOrdSet<A, P: SharedPointerKind> {
     size: usize,
-    pool: OrdSetPool<A, P>,
     root: SharedPointer<Node<Value<A>, P>, P>,
 }
 
@@ -137,13 +133,8 @@ impl<A, P: SharedPointerKind> GenericOrdSet<A, P> {
     #[inline]
     #[must_use]
     pub fn new() -> Self {
-        let pool = OrdSetPool::default();
         let root = SharedPointer::default();
-        GenericOrdSet {
-            size: 0,
-            pool,
-            root,
-        }
+        GenericOrdSet { size: 0, root }
     }
 
     /// Construct a set with a single value.
@@ -159,13 +150,8 @@ impl<A, P: SharedPointerKind> GenericOrdSet<A, P> {
     #[inline]
     #[must_use]
     pub fn unit(a: A) -> Self {
-        let pool = OrdSetPool::default();
         let root = SharedPointer::new(Node::unit(Value(a)));
-        GenericOrdSet {
-            size: 1,
-            pool,
-            root,
-        }
+        GenericOrdSet { size: 1, root }
     }
 
     /// Test whether a set is empty.
@@ -476,14 +462,14 @@ where
     pub fn insert(&mut self, a: A) -> Option<A> {
         let new_root = {
             let root = SharedPointer::make_mut(&mut self.root);
-            match root.insert(&self.pool.0, Value(a)) {
+            match root.insert(Value(a)) {
                 Insert::Replaced(Value(old_value)) => return Some(old_value),
                 Insert::Added => {
                     self.size += 1;
                     return None;
                 }
                 Insert::Split(left, median, right) => {
-                    SharedPointer::new(Node::new_from_split(&self.pool.0, left, median, right))
+                    SharedPointer::new(Node::new_from_split(left, median, right))
                 }
             }
         };
@@ -503,7 +489,7 @@ where
     {
         let (new_root, removed_value) = {
             let root = SharedPointer::make_mut(&mut self.root);
-            match root.remove(&self.pool.0, a) {
+            match root.remove(a) {
                 Remove::Update(value, root) => (SharedPointer::new(root), Some(value.0)),
                 Remove::Removed(value) => {
                     self.size -= 1;
@@ -823,7 +809,6 @@ impl<A, P: SharedPointerKind> Clone for GenericOrdSet<A, P> {
     fn clone(&self) -> Self {
         GenericOrdSet {
             size: self.size,
-            pool: self.pool.clone(),
             root: self.root.clone(),
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,10 +8,8 @@ use std::cmp::Ordering;
 use std::ops::{Bound, Range, RangeBounds};
 
 use archery::{SharedPointer, SharedPointerKind};
-#[cfg(feature = "pool")]
-pub(crate) use refpool::{PoolClone, PoolDefault};
 
-pub(crate) use crate::fakepool::{Pool, PoolClone, PoolDefault};
+pub(crate) use crate::fakepool::Pool;
 
 pub(crate) fn clone_ref<A, P>(r: SharedPointer<A, P>) -> A
 where

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,8 +9,6 @@ use std::ops::{Bound, Range, RangeBounds};
 
 use archery::{SharedPointer, SharedPointerKind};
 
-pub(crate) use crate::fakepool::Pool;
-
 pub(crate) fn clone_ref<A, P>(r: SharedPointer<A, P>) -> A
 where
     A: Clone,
@@ -59,42 +57,6 @@ where
         Bound::Unbounded => right_unbounded,
     };
     start_index..end_index
-}
-
-macro_rules! def_pool {
-    ($name:ident<$($arg:tt),*>, $pooltype:ty) => {
-        /// A memory pool for the appropriate node type.
-        pub struct $name<$($arg,)* P: ::archery::SharedPointerKind>(Pool<$pooltype>);
-
-        impl<$($arg,)* P: ::archery::SharedPointerKind> $name<$($arg,)* P> {
-            /// Create a new pool with the given size.
-            pub fn new(size: usize) -> Self {
-                Self(Pool::new(size))
-            }
-
-            /// Fill the pool with preallocated chunks.
-            pub fn fill(&self) {
-                self.0.fill();
-            }
-
-            ///Get the current size of the pool.
-            pub fn pool_size(&self) -> usize {
-                self.0.get_pool_size()
-            }
-        }
-
-        impl<$($arg,)* P: ::archery::SharedPointerKind> Default for $name<$($arg,)* P> {
-            fn default() -> Self {
-                Self::new($crate::config::POOL_SIZE)
-            }
-        }
-
-        impl<$($arg,)* P: ::archery::SharedPointerKind> Clone for $name<$($arg,)* P> {
-            fn clone(&self) -> Self {
-                Self(self.0.clone())
-            }
-        }
-    };
 }
 
 #[cfg(test)]

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -61,16 +61,13 @@ use crate::nodes::chunk::{Chunk, CHUNK_SIZE};
 use crate::nodes::rrb::{Node, PopResult, PushResult, SplitResult};
 use crate::shared_ptr::DefaultSharedPtr;
 use crate::sort;
-use crate::util::{clone_ref, to_range, Pool, Side};
+use crate::util::{clone_ref, to_range, Side};
 
 use self::VectorInner::{Full, Inline, Single};
 
 mod focus;
 
 pub use self::focus::{Focus, FocusMut};
-
-mod pool;
-pub use self::pool::RRBPool;
 
 #[cfg(any(test, feature = "rayon"))]
 pub mod rayon;
@@ -157,9 +154,9 @@ pub struct GenericVector<A, P: SharedPointerKind> {
 }
 
 enum VectorInner<A, P: SharedPointerKind> {
-    Inline(RRBPool<A, P>, InlineArray<A, RRB<A, P>>),
-    Single(RRBPool<A, P>, SharedPointer<Chunk<A>, P>),
-    Full(RRBPool<A, P>, RRB<A, P>),
+    Inline(InlineArray<A, RRB<A, P>>),
+    Single(SharedPointer<Chunk<A>, P>),
+    Full(RRB<A, P>),
 }
 
 #[doc(hidden)]
@@ -188,19 +185,6 @@ impl<A, P: SharedPointerKind> Clone for RRB<A, P> {
 }
 
 impl<A, P: SharedPointerKind> GenericVector<A, P> {
-    /// Get a reference to the memory pool this `Vector` is using.
-    ///
-    /// Note that if you didn't specifically construct it with a pool, you'll
-    /// get back a reference to a pool of size 0.
-    #[doc(hidden)]
-    pub fn pool(&self) -> &RRBPool<A, P> {
-        match self.vector {
-            Inline(ref pool, _) => pool,
-            Single(ref pool, _) => pool,
-            Full(ref pool, _) => pool,
-        }
-    }
-
     /// True if a vector is a full inline or single chunk, ie. must be promoted
     /// to grow further.
     fn needs_promotion(&self) -> bool {
@@ -209,16 +193,16 @@ impl<A, P: SharedPointerKind> GenericVector<A, P> {
             // can always promote `Inline` to `Single`, even when we're configured to have a small
             // chunk size. (TODO: it might be better to just never use `Single` in this situation,
             // but that's a more invasive change.)
-            Inline(_, chunk) => chunk.is_full() || chunk.len() + 1 >= CHUNK_SIZE,
-            Single(_, chunk) => chunk.is_full(),
+            Inline(chunk) => chunk.is_full() || chunk.len() + 1 >= CHUNK_SIZE,
+            Single(chunk) => chunk.is_full(),
             _ => false,
         }
     }
 
     /// Promote an inline to a single.
     fn promote_inline(&mut self) {
-        if let Inline(pool, chunk) = &mut self.vector {
-            self.vector = Single(pool.clone(), SharedPointer::new(chunk.into()));
+        if let Inline(chunk) = &mut self.vector {
+            self.vector = Single(SharedPointer::new(chunk.into()));
         }
     }
 
@@ -226,23 +210,20 @@ impl<A, P: SharedPointerKind> GenericVector<A, P> {
     /// promote an inline to a single.
     fn promote_front(&mut self) {
         self.vector = match &mut self.vector {
-            Inline(pool, chunk) => Single(pool.clone(), SharedPointer::new(chunk.into())),
-            Single(pool, chunk) => {
+            Inline(chunk) => Single(SharedPointer::new(chunk.into())),
+            Single(chunk) => {
                 let chunk = chunk.clone();
-                Full(
-                    pool.clone(),
-                    RRB {
-                        length: chunk.len(),
-                        middle_level: 0,
-                        outer_f: SharedPointer::default(),
-                        inner_f: chunk,
-                        middle: SharedPointer::new(Node::new()),
-                        inner_b: SharedPointer::default(),
-                        outer_b: SharedPointer::default(),
-                    },
-                )
+                Full(RRB {
+                    length: chunk.len(),
+                    middle_level: 0,
+                    outer_f: SharedPointer::default(),
+                    inner_f: chunk,
+                    middle: SharedPointer::new(Node::new()),
+                    inner_b: SharedPointer::default(),
+                    outer_b: SharedPointer::default(),
+                })
             }
-            Full(_, _) => return,
+            Full(_) => return,
         }
     }
 
@@ -250,23 +231,20 @@ impl<A, P: SharedPointerKind> GenericVector<A, P> {
     /// promote an inline to a single.
     fn promote_back(&mut self) {
         self.vector = match &mut self.vector {
-            Inline(pool, chunk) => Single(pool.clone(), SharedPointer::new(chunk.into())),
-            Single(pool, chunk) => {
+            Inline(chunk) => Single(SharedPointer::new(chunk.into())),
+            Single(chunk) => {
                 let chunk = chunk.clone();
-                Full(
-                    pool.clone(),
-                    RRB {
-                        length: chunk.len(),
-                        middle_level: 0,
-                        outer_f: SharedPointer::default(),
-                        inner_f: SharedPointer::default(),
-                        middle: SharedPointer::new(Node::new()),
-                        inner_b: chunk,
-                        outer_b: SharedPointer::default(),
-                    },
-                )
+                Full(RRB {
+                    length: chunk.len(),
+                    middle_level: 0,
+                    outer_f: SharedPointer::default(),
+                    inner_f: SharedPointer::default(),
+                    middle: SharedPointer::new(Node::new()),
+                    inner_b: chunk,
+                    outer_b: SharedPointer::default(),
+                })
             }
-            Full(_, _) => return,
+            Full(_) => return,
         }
     }
 
@@ -274,7 +252,7 @@ impl<A, P: SharedPointerKind> GenericVector<A, P> {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            vector: Inline(RRBPool::default(), InlineArray::new()),
+            vector: Inline(InlineArray::new()),
         }
     }
 
@@ -294,9 +272,9 @@ impl<A, P: SharedPointerKind> GenericVector<A, P> {
     #[must_use]
     pub fn len(&self) -> usize {
         match &self.vector {
-            Inline(_, chunk) => chunk.len(),
-            Single(_, chunk) => chunk.len(),
-            Full(_, tree) => tree.length,
+            Inline(chunk) => chunk.len(),
+            Single(chunk) => chunk.len(),
+            Full(tree) => tree.length,
         }
     }
 
@@ -337,7 +315,7 @@ impl<A, P: SharedPointerKind> GenericVector<A, P> {
     #[inline]
     #[must_use]
     pub fn is_inline(&self) -> bool {
-        matches!(self.vector, Inline(_, _))
+        matches!(self.vector, Inline(_))
     }
 
     /// Test whether two vectors refer to the same content in memory.
@@ -368,8 +346,8 @@ impl<A, P: SharedPointerKind> GenericVector<A, P> {
         }
 
         match (&self.vector, &other.vector) {
-            (Single(_, left), Single(_, right)) => cmp_chunk(left, right),
-            (Full(_, left), Full(_, right)) => {
+            (Single(left), Single(right)) => cmp_chunk(left, right),
+            (Full(left), Full(right)) => {
                 cmp_chunk(&left.outer_f, &right.outer_f)
                     && cmp_chunk(&left.inner_f, &right.inner_f)
                     && cmp_chunk(&left.inner_b, &right.inner_b)
@@ -437,9 +415,9 @@ impl<A, P: SharedPointerKind> GenericVector<A, P> {
         }
 
         match &self.vector {
-            Inline(_, chunk) => chunk.get(index),
-            Single(_, chunk) => chunk.get(index),
-            Full(_, tree) => {
+            Inline(chunk) => chunk.get(index),
+            Single(chunk) => chunk.get(index),
+            Full(tree) => {
                 let mut local_index = index;
 
                 if local_index < tree.outer_f.len() {
@@ -584,7 +562,7 @@ impl<A, P: SharedPointerKind> GenericVector<A, P> {
     /// Time: O(n)
     pub fn clear(&mut self) {
         if !self.is_empty() {
-            self.vector = Inline(self.pool().clone(), InlineArray::new());
+            self.vector = Inline(InlineArray::new());
         }
     }
 
@@ -681,17 +659,16 @@ impl<A, P: SharedPointerKind> GenericVector<A, P> {
     #[inline]
     #[must_use]
     pub fn unit(a: A) -> Self {
-        let pool = RRBPool::default();
         if InlineArray::<A, RRB<A, P>>::CAPACITY > 0 {
             let mut array = InlineArray::new();
             array.push(a);
             Self {
-                vector: Inline(pool, array),
+                vector: Inline(array),
             }
         } else {
             let chunk = SharedPointer::new(Chunk::unit(a));
             Self {
-                vector: Single(pool, chunk),
+                vector: Single(chunk),
             }
         }
     }
@@ -701,7 +678,7 @@ impl<A, P: SharedPointerKind> GenericVector<A, P> {
     /// This method requires the `debug` feature flag.
     #[cfg(any(test, feature = "debug"))]
     pub fn dot<W: std::io::Write>(&self, write: W) -> std::io::Result<()> {
-        if let Full(_, ref tree) = self.vector {
+        if let Full(ref tree) = self.vector {
             tree.middle.dot(write)
         } else {
             Ok(())
@@ -717,7 +694,7 @@ impl<A, P: SharedPointerKind> GenericVector<A, P> {
     /// This method requires the `debug` feature flag.
     #[cfg(any(test, feature = "debug"))]
     pub fn assert_invariants(&self) {
-        if let Full(_, ref tree) = self.vector {
+        if let Full(ref tree) = self.vector {
             tree.assert_invariants();
         }
     }
@@ -750,9 +727,9 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
         }
 
         match &mut self.vector {
-            Inline(_, chunk) => chunk.get_mut(index),
-            Single(_pool, chunk) => SharedPointer::make_mut(chunk).get_mut(index),
-            Full(pool, tree) => {
+            Inline(chunk) => chunk.get_mut(index),
+            Single(chunk) => SharedPointer::make_mut(chunk).get_mut(index),
+            Full(tree) => {
                 let mut local_index = index;
 
                 if local_index < tree.outer_f.len() {
@@ -769,7 +746,7 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
 
                 if local_index < tree.middle.len() {
                     let middle = SharedPointer::make_mut(&mut tree.middle);
-                    return Some(middle.index_mut(pool, tree.middle_level, local_index));
+                    return Some(middle.index_mut(tree.middle_level, local_index));
                 }
                 local_index -= tree.middle.len();
 
@@ -911,11 +888,11 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
             self.promote_back();
         }
         match &mut self.vector {
-            Inline(_, chunk) => {
+            Inline(chunk) => {
                 chunk.insert(0, value);
             }
-            Single(_pool, chunk) => SharedPointer::make_mut(chunk).push_front(value),
-            Full(pool, tree) => tree.push_front(pool, value),
+            Single(chunk) => SharedPointer::make_mut(chunk).push_front(value),
+            Full(tree) => tree.push_front(value),
         }
     }
 
@@ -936,11 +913,11 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
             self.promote_front();
         }
         match &mut self.vector {
-            Inline(_, chunk) => {
+            Inline(chunk) => {
                 chunk.push(value);
             }
-            Single(_pool, chunk) => SharedPointer::make_mut(chunk).push_back(value),
-            Full(pool, tree) => tree.push_back(pool, value),
+            Single(chunk) => SharedPointer::make_mut(chunk).push_back(value),
+            Full(tree) => tree.push_back(value),
         }
     }
 
@@ -961,9 +938,9 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
             None
         } else {
             match &mut self.vector {
-                Inline(_, chunk) => chunk.remove(0),
-                Single(_pool, chunk) => Some(SharedPointer::make_mut(chunk).pop_front()),
-                Full(pool, tree) => tree.pop_front(pool),
+                Inline(chunk) => chunk.remove(0),
+                Single(chunk) => Some(SharedPointer::make_mut(chunk).pop_front()),
+                Full(tree) => tree.pop_front(),
             }
         }
     }
@@ -986,9 +963,9 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
             None
         } else {
             match &mut self.vector {
-                Inline(_, chunk) => chunk.pop(),
-                Single(_pool, chunk) => Some(SharedPointer::make_mut(chunk).pop_back()),
-                Full(pool, tree) => tree.pop_back(pool),
+                Inline(chunk) => chunk.pop(),
+                Single(chunk) => Some(SharedPointer::make_mut(chunk).pop_back()),
+                Full(tree) => tree.pop_back(),
             }
         }
     }
@@ -1024,13 +1001,13 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
             .expect("Vector length overflow");
 
         match &mut self.vector {
-            Inline(_, _) => unreachable!("inline vecs should have been promoted"),
-            Single(_pool, left) => {
+            Inline(_) => unreachable!("inline vecs should have been promoted"),
+            Single(left) => {
                 match &mut other.vector {
-                    Inline(_, _) => unreachable!("inline vecs should have been promoted"),
+                    Inline(_) => unreachable!("inline vecs should have been promoted"),
                     // If both are single chunks and left has room for right: directly
                     // memcpy right into left
-                    Single(_, ref mut right) if total_length <= CHUNK_SIZE => {
+                    Single(ref mut right) if total_length <= CHUNK_SIZE => {
                         SharedPointer::make_mut(left).append(SharedPointer::make_mut(right));
                         return;
                     }
@@ -1045,8 +1022,8 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
                     _ => {}
                 }
             }
-            Full(pool, left) => {
-                if let Full(_, mut right) = other.vector {
+            Full(left) => {
+                if let Full(mut right) = other.vector {
                     // If left and right are trees with empty middles, left has no back
                     // buffers, and right has no front buffers: copy right's back
                     // buffers over to left
@@ -1068,37 +1045,37 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
                         && right.middle.is_empty()
                         && total_length <= CHUNK_SIZE * 4
                     {
-                        while let Some(value) = right.pop_front(pool) {
-                            left.push_back(pool, value);
+                        while let Some(value) = right.pop_front() {
+                            left.push_back(value);
                         }
                         return;
                     }
                     // Both are full and big: do the full RRB join
                     let inner_b1 = left.inner_b.clone();
-                    left.push_middle(pool, Side::Right, inner_b1);
+                    left.push_middle(Side::Right, inner_b1);
                     let outer_b1 = left.outer_b.clone();
-                    left.push_middle(pool, Side::Right, outer_b1);
+                    left.push_middle(Side::Right, outer_b1);
                     let inner_f2 = right.inner_f.clone();
-                    right.push_middle(pool, Side::Left, inner_f2);
+                    right.push_middle(Side::Left, inner_f2);
                     let outer_f2 = right.outer_f.clone();
-                    right.push_middle(pool, Side::Left, outer_f2);
+                    right.push_middle(Side::Left, outer_f2);
 
                     let mut middle1 =
                         clone_ref(replace(&mut left.middle, SharedPointer::new(Node::new())));
                     let mut middle2 = clone_ref(right.middle);
                     let normalised_middle = match left.middle_level.cmp(&right.middle_level) {
                         Ordering::Greater => {
-                            middle2 = middle2.elevate(pool, left.middle_level - right.middle_level);
+                            middle2 = middle2.elevate(left.middle_level - right.middle_level);
                             left.middle_level
                         }
                         Ordering::Less => {
-                            middle1 = middle1.elevate(pool, right.middle_level - left.middle_level);
+                            middle1 = middle1.elevate(right.middle_level - left.middle_level);
                             right.middle_level
                         }
                         Ordering::Equal => left.middle_level,
                     };
                     left.middle =
-                        SharedPointer::new(Node::merge(pool, middle1, middle2, normalised_middle));
+                        SharedPointer::new(Node::merge(middle1, middle2, normalised_middle));
                     left.middle_level = normalised_middle + 1;
 
                     left.inner_b = right.inner_b;
@@ -1187,16 +1164,15 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
         assert!(index <= self.len());
 
         match &mut self.vector {
-            Inline(pool, chunk) => Self {
-                vector: Inline(pool.clone(), chunk.split_off(index)),
+            Inline(chunk) => Self {
+                vector: Inline(chunk.split_off(index)),
             },
-            Single(pool, chunk) => Self {
-                vector: Single(
-                    pool.clone(),
-                    SharedPointer::new(SharedPointer::make_mut(chunk).split_off(index)),
-                ),
+            Single(chunk) => Self {
+                vector: Single(SharedPointer::new(
+                    SharedPointer::make_mut(chunk).split_off(index),
+                )),
             },
-            Full(pool, tree) => {
+            Full(tree) => {
                 let mut local_index = index;
 
                 if local_index < tree.outer_f.len() {
@@ -1205,15 +1181,15 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
                         length: tree.length - index,
                         middle_level: tree.middle_level,
                         outer_f: SharedPointer::new(of2),
-                        inner_f: replace_shared_pointer(&pool.value_pool, &mut tree.inner_f),
+                        inner_f: replace_shared_pointer(&mut tree.inner_f),
                         middle: std::mem::take(&mut tree.middle),
-                        inner_b: replace_shared_pointer(&pool.value_pool, &mut tree.inner_b),
-                        outer_b: replace_shared_pointer(&pool.value_pool, &mut tree.outer_b),
+                        inner_b: replace_shared_pointer(&mut tree.inner_b),
+                        outer_b: replace_shared_pointer(&mut tree.outer_b),
                     };
                     tree.length = index;
                     tree.middle_level = 0;
                     return Self {
-                        vector: Full(pool.clone(), right),
+                        vector: Full(right),
                     };
                 }
 
@@ -1227,14 +1203,14 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
                         outer_f: SharedPointer::new(if2),
                         inner_f: SharedPointer::default(),
                         middle: std::mem::take(&mut tree.middle),
-                        inner_b: replace_shared_pointer(&pool.value_pool, &mut tree.inner_b),
-                        outer_b: replace_shared_pointer(&pool.value_pool, &mut tree.outer_b),
+                        inner_b: replace_shared_pointer(&mut tree.inner_b),
+                        outer_b: replace_shared_pointer(&mut tree.outer_b),
                     };
                     tree.length = index;
                     tree.middle_level = 0;
                     swap(&mut tree.outer_b, &mut tree.inner_f);
                     return Self {
-                        vector: Full(pool.clone(), right),
+                        vector: Full(right),
                     };
                 }
 
@@ -1245,15 +1221,15 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
                     let (c1, c2) = {
                         let m1 = SharedPointer::make_mut(&mut tree.middle);
                         let m2 = SharedPointer::make_mut(&mut right_middle);
-                        match m1.split(pool, tree.middle_level, Side::Right, local_index) {
+                        match m1.split(tree.middle_level, Side::Right, local_index) {
                             SplitResult::Dropped(_) => (),
                             SplitResult::OutOfBounds => unreachable!(),
                         };
-                        match m2.split(pool, tree.middle_level, Side::Left, local_index) {
+                        match m2.split(tree.middle_level, Side::Left, local_index) {
                             SplitResult::Dropped(_) => (),
                             SplitResult::OutOfBounds => unreachable!(),
                         };
-                        let c1 = match m1.pop_chunk(pool, tree.middle_level, Side::Right) {
+                        let c1 = match m1.pop_chunk(tree.middle_level, Side::Right) {
                             PopResult::Empty => SharedPointer::default(),
                             PopResult::Done(chunk) => chunk,
                             PopResult::Drained(chunk) => {
@@ -1261,7 +1237,7 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
                                 chunk
                             }
                         };
-                        let c2 = match m2.pop_chunk(pool, tree.middle_level, Side::Left) {
+                        let c2 = match m2.pop_chunk(tree.middle_level, Side::Left) {
                             PopResult::Empty => SharedPointer::default(),
                             PopResult::Done(chunk) => chunk,
                             PopResult::Drained(chunk) => {
@@ -1277,14 +1253,14 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
                         outer_f: c2,
                         inner_f: SharedPointer::default(),
                         middle: right_middle,
-                        inner_b: replace_shared_pointer(&pool.value_pool, &mut tree.inner_b),
+                        inner_b: replace_shared_pointer(&mut tree.inner_b),
                         outer_b: replace(&mut tree.outer_b, c1),
                     };
                     tree.length = index;
                     tree.prune();
                     right.prune();
                     return Self {
-                        vector: Full(pool.clone(), right),
+                        vector: Full(right),
                     };
                 }
 
@@ -1294,14 +1270,14 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
                     let ib2 = SharedPointer::make_mut(&mut tree.inner_b).split_off(local_index);
                     let right = RRB {
                         length: tree.length - index,
-                        outer_b: replace_shared_pointer(&pool.value_pool, &mut tree.outer_b),
+                        outer_b: replace_shared_pointer(&mut tree.outer_b),
                         outer_f: SharedPointer::new(ib2),
-                        ..RRB::new(pool)
+                        ..RRB::new()
                     };
                     tree.length = index;
                     swap(&mut tree.outer_b, &mut tree.inner_b);
                     return Self {
-                        vector: Full(pool.clone(), right),
+                        vector: Full(right),
                     };
                 }
 
@@ -1310,7 +1286,7 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
                 let ob2 = SharedPointer::make_mut(&mut tree.outer_b).split_off(local_index);
                 tree.length = index;
                 Self {
-                    vector: Single(pool.clone(), SharedPointer::new(ob2)),
+                    vector: Single(SharedPointer::new(ob2)),
                 }
             }
         }
@@ -1398,14 +1374,14 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
             return self.push_back(value);
         }
         assert!(index < self.len());
-        if matches!(&self.vector, Inline(_, _)) && self.needs_promotion() {
+        if matches!(&self.vector, Inline(_)) && self.needs_promotion() {
             self.promote_inline();
         }
         match &mut self.vector {
-            Inline(_, chunk) => {
+            Inline(chunk) => {
                 chunk.insert(index, value);
             }
-            Single(_pool, chunk) if chunk.len() < CHUNK_SIZE => {
+            Single(chunk) if chunk.len() < CHUNK_SIZE => {
                 SharedPointer::make_mut(chunk).insert(index, value)
             }
             // TODO a lot of optimisations still possible here
@@ -1436,8 +1412,8 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
     pub fn remove(&mut self, index: usize) -> A {
         assert!(index < self.len());
         match &mut self.vector {
-            Inline(_, chunk) => chunk.remove(index).unwrap(),
-            Single(_pool, chunk) => SharedPointer::make_mut(chunk).remove(index),
+            Inline(chunk) => chunk.remove(index).unwrap(),
+            Single(chunk) => SharedPointer::make_mut(chunk).remove(index),
             _ => {
                 if index == 0 {
                     return self.pop_front().unwrap();
@@ -1605,7 +1581,7 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
 // Implementation details
 
 impl<A, P: SharedPointerKind> RRB<A, P> {
-    fn new(_pool: &RRBPool<A, P>) -> Self {
+    fn new() -> Self {
         RRB {
             length: 0,
             middle_level: 0,
@@ -1641,7 +1617,7 @@ impl<A: Clone, P: SharedPointerKind> RRB<A, P> {
         }
     }
 
-    fn pop_front(&mut self, pool: &RRBPool<A, P>) -> Option<A> {
+    fn pop_front(&mut self) -> Option<A> {
         if self.length == 0 {
             return None;
         }
@@ -1654,7 +1630,7 @@ impl<A: Clone, P: SharedPointerKind> RRB<A, P> {
                         swap(&mut self.outer_f, &mut self.inner_b);
                     }
                 } else {
-                    self.outer_f = self.pop_middle(pool, Side::Left).unwrap();
+                    self.outer_f = self.pop_middle(Side::Left).unwrap();
                 }
             } else {
                 swap(&mut self.outer_f, &mut self.inner_f);
@@ -1665,7 +1641,7 @@ impl<A: Clone, P: SharedPointerKind> RRB<A, P> {
         Some(outer_f.pop_front())
     }
 
-    fn pop_back(&mut self, pool: &RRBPool<A, P>) -> Option<A> {
+    fn pop_back(&mut self) -> Option<A> {
         if self.length == 0 {
             return None;
         }
@@ -1678,7 +1654,7 @@ impl<A: Clone, P: SharedPointerKind> RRB<A, P> {
                         swap(&mut self.outer_b, &mut self.inner_f);
                     }
                 } else {
-                    self.outer_b = self.pop_middle(pool, Side::Right).unwrap();
+                    self.outer_b = self.pop_middle(Side::Right).unwrap();
                 }
             } else {
                 swap(&mut self.outer_b, &mut self.inner_b);
@@ -1689,13 +1665,13 @@ impl<A: Clone, P: SharedPointerKind> RRB<A, P> {
         Some(outer_b.pop_back())
     }
 
-    fn push_front(&mut self, pool: &RRBPool<A, P>, value: A) {
+    fn push_front(&mut self, value: A) {
         if self.outer_f.is_full() {
             swap(&mut self.outer_f, &mut self.inner_f);
             if !self.outer_f.is_empty() {
                 let mut chunk = SharedPointer::new(Chunk::new());
                 swap(&mut chunk, &mut self.outer_f);
-                self.push_middle(pool, Side::Left, chunk);
+                self.push_middle(Side::Left, chunk);
             }
         }
         self.length = self.length.checked_add(1).expect("Vector length overflow");
@@ -1703,13 +1679,13 @@ impl<A: Clone, P: SharedPointerKind> RRB<A, P> {
         outer_f.push_front(value)
     }
 
-    fn push_back(&mut self, pool: &RRBPool<A, P>, value: A) {
+    fn push_back(&mut self, value: A) {
         if self.outer_b.is_full() {
             swap(&mut self.outer_b, &mut self.inner_b);
             if !self.outer_b.is_empty() {
                 let mut chunk = SharedPointer::new(Chunk::new());
                 swap(&mut chunk, &mut self.outer_b);
-                self.push_middle(pool, Side::Right, chunk);
+                self.push_middle(Side::Right, chunk);
             }
         }
         self.length = self.length.checked_add(1).expect("Vector length overflow");
@@ -1717,21 +1693,20 @@ impl<A: Clone, P: SharedPointerKind> RRB<A, P> {
         outer_b.push_back(value)
     }
 
-    fn push_middle(&mut self, pool: &RRBPool<A, P>, side: Side, chunk: SharedPointer<Chunk<A>, P>) {
+    fn push_middle(&mut self, side: Side, chunk: SharedPointer<Chunk<A>, P>) {
         if chunk.is_empty() {
             return;
         }
         let new_middle = {
             let middle = SharedPointer::make_mut(&mut self.middle);
-            match middle.push_chunk(pool, self.middle_level, side, chunk) {
+            match middle.push_chunk(self.middle_level, side, chunk) {
                 PushResult::Done => return,
                 PushResult::Full(chunk, _num_drained) => SharedPointer::new({
                     match side {
-                        Side::Left => Node::from_chunk(pool, self.middle_level, chunk)
-                            .join_branches(pool, middle.clone(), self.middle_level),
+                        Side::Left => Node::from_chunk(self.middle_level, chunk)
+                            .join_branches(middle.clone(), self.middle_level),
                         Side::Right => middle.clone().join_branches(
-                            pool,
-                            Node::from_chunk(pool, self.middle_level, chunk),
+                            Node::from_chunk(self.middle_level, chunk),
                             self.middle_level,
                         ),
                     }
@@ -1742,14 +1717,10 @@ impl<A: Clone, P: SharedPointerKind> RRB<A, P> {
         self.middle = new_middle;
     }
 
-    fn pop_middle(
-        &mut self,
-        pool: &RRBPool<A, P>,
-        side: Side,
-    ) -> Option<SharedPointer<Chunk<A>, P>> {
+    fn pop_middle(&mut self, side: Side) -> Option<SharedPointer<Chunk<A>, P>> {
         let chunk = {
             let middle = SharedPointer::make_mut(&mut self.middle);
-            match middle.pop_chunk(pool, self.middle_level, side) {
+            match middle.pop_chunk(self.middle_level, side) {
                 PopResult::Empty => return None,
                 PopResult::Done(chunk) => chunk,
                 PopResult::Drained(chunk) => {
@@ -1765,7 +1736,6 @@ impl<A: Clone, P: SharedPointerKind> RRB<A, P> {
 
 #[inline]
 fn replace_shared_pointer<A: Default, P: SharedPointerKind>(
-    _pool: &Pool<A>,
     dest: &mut SharedPointer<A, P>,
 ) -> SharedPointer<A, P> {
     std::mem::take(dest)
@@ -1786,9 +1756,9 @@ impl<A: Clone, P: SharedPointerKind> Clone for GenericVector<A, P> {
     fn clone(&self) -> Self {
         Self {
             vector: match &self.vector {
-                Inline(pool, chunk) => Inline(pool.clone(), chunk.clone()),
-                Single(pool, chunk) => Single(pool.clone(), chunk.clone()),
-                Full(pool, tree) => Full(pool.clone(), tree.clone()),
+                Inline(chunk) => Inline(chunk.clone()),
+                Single(chunk) => Single(chunk.clone()),
+                Full(tree) => Full(tree.clone()),
             },
         }
     }
@@ -2503,7 +2473,7 @@ mod test {
         // respectively. Previously the next `push_back()` would append another
         // zero-sized chunk to middle even though there is enough space left.
         match x.vector {
-            VectorInner::Full(_, ref tree) => {
+            VectorInner::Full(ref tree) => {
                 assert_eq!(129, tree.middle.len());
                 assert_eq!(3, tree.middle.number_of_children());
             }
@@ -2511,7 +2481,7 @@ mod test {
         }
         x.push_back(0);
         match x.vector {
-            VectorInner::Full(_, ref tree) => {
+            VectorInner::Full(ref tree) => {
                 assert_eq!(131, tree.middle.len());
                 assert_eq!(3, tree.middle.number_of_children())
             }
@@ -2565,7 +2535,7 @@ mod test {
         // remaining 63 elements will end up in a new node.
         x.push_back(0u32);
         match x.vector {
-            VectorInner::Full(_, tree) => {
+            VectorInner::Full(tree) => {
                 if CHUNK_SIZE == 64 {
                     assert_eq!(3, tree.middle.number_of_children());
                 }
@@ -2680,7 +2650,7 @@ mod test {
         let mut a = Vector::from_iter(0..128);
         let b = Vector::from_iter(128..256);
         a.append(b);
-        assert!(matches!(a.vector, Full(_, _)));
+        assert!(matches!(a.vector, Full(_)));
         a.retain(|i| *i % 2 == 0);
         assert_eq!(a.len(), 128);
     }


### PR DESCRIPTION
This cleans up a lot of warnings, by removing the unused support for specialization and memory pools.