### PR TITLE
fix: `vector::Iter` is not `Clone` when `triomphe` is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix `vector::Iter` is not `Clone` when `triomphe` is enabled (#107)
+
 ## [5.0.0] - 2025-02-12
 
 ### Added

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1990,7 +1990,6 @@ impl<'a, A: Clone, P: SharedPointerKind> From<&'a Vec<A>> for GenericVector<A, P
 /// [iter]: enum.Vector.html#method.iter
 // TODO: we'd like to support Clone even if A is not Clone, but it isn't trivial because
 // the TreeFocus variant of Focus does need A to be Clone.
-#[derive(Clone)]
 pub struct Iter<'a, A, P: SharedPointerKind> {
     focus: Focus<'a, A, P>,
     front_index: usize,
@@ -2011,6 +2010,16 @@ impl<'a, A, P: SharedPointerKind> Iter<'a, A, P> {
             front_index: 0,
             back_index: focus.len(),
             focus,
+        }
+    }
+}
+
+impl<A: Clone, P: SharedPointerKind> Clone for Iter<'_, A, P> {
+    fn clone(&self) -> Self {
+        Iter {
+            focus: self.focus.clone(),
+            front_index: self.front_index,
+            back_index: self.back_index,
         }
     }
 }


### PR DESCRIPTION
Manually implement `Clone` for `vector::Iter` to avoid overly strict trait bounds introduced by `#[derive(Clone)]`.