### PR TITLE
Rewrite OrdMap as a B+Tree for better performance and readability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,4 +64,4 @@ jobs:
       - name: install cargo-fuzz
         run: cargo install cargo-fuzz
       - name: run tests
-        run: for fuzz_test in `cargo fuzz list`; do cargo fuzz run $fuzz_test -- -max_total_time=10 || exit 1; done
+        run: for fuzz_test in `cargo fuzz list`; do cargo fuzz run $fuzz_test -- -len_control=0 -max_total_time=60 || exit 1; done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "imbl"
 version = "5.0.0"
-authors = ["Bodil Stokke <bodil@bodil.org>", "Joe Neeman <joeneeman@gmail.com>"]
+authors = [
+    "Bodil Stokke <bodil@bodil.org>",
+    "Joe Neeman <joeneeman@gmail.com>",
+    "Arthur Silva <arthurprs@gmail.com>",
+]
 edition = "2018"
 license = "MPL-2.0+"
 rust-version = "1.77"
@@ -57,3 +61,7 @@ pretty_assertions = "1.0"
 metrohash = "1"
 proptest-derive = "0.5"
 static_assertions = "1.1.0"
+
+# Include debug symbols when benchmarking, this is useful for profiling
+[profile.bench]
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,6 @@ static_assertions = "1.1.0"
 # Include debug symbols when benchmarking, this is useful for profiling
 [profile.bench]
 debug = true
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/benches/ordmap.rs
+++ b/benches/ordmap.rs
@@ -8,6 +8,7 @@ extern crate imbl;
 extern crate rand;
 extern crate test;
 
+use rand::seq::SliceRandom;
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::collections::BTreeSet;
 use std::iter::FromIterator;
@@ -19,7 +20,7 @@ fn random_keys(size: usize) -> Vec<i64> {
     let mut gen = SmallRng::seed_from_u64(1);
     let mut set = BTreeSet::new();
     while set.len() < size {
-        let next = gen.random::<i64>() % 10000;
+        let next = gen.random::<i64>();
         set.insert(next);
     }
     set.into_iter().collect()
@@ -27,13 +28,8 @@ fn random_keys(size: usize) -> Vec<i64> {
 
 fn reorder<A: Copy>(vec: &[A]) -> Vec<A> {
     let mut gen = SmallRng::seed_from_u64(1);
-    let mut set: Vec<A> = vec.to_owned();
-    let mut out = Vec::new();
-    while !set.is_empty() {
-        let i = gen.random::<u64>() as usize % set.len();
-        let v = set.remove(i);
-        out.push(v)
-    }
+    let mut out = vec.to_vec();
+    out.shuffle(&mut gen);
     out
 }
 
@@ -49,11 +45,6 @@ fn ordmap_lookup_n(size: usize, b: &mut Bencher) {
 }
 
 #[bench]
-fn ordmap_lookup_10(b: &mut Bencher) {
-    ordmap_lookup_n(10, b)
-}
-
-#[bench]
 fn ordmap_lookup_100(b: &mut Bencher) {
     ordmap_lookup_n(100, b)
 }
@@ -61,6 +52,16 @@ fn ordmap_lookup_100(b: &mut Bencher) {
 #[bench]
 fn ordmap_lookup_1000(b: &mut Bencher) {
     ordmap_lookup_n(1000, b)
+}
+
+#[bench]
+fn ordmap_lookup_10000(b: &mut Bencher) {
+    ordmap_lookup_n(10000, b)
+}
+
+#[bench]
+fn ordmap_lookup_100000(b: &mut Bencher) {
+    ordmap_lookup_n(100000, b)
 }
 
 fn ordmap_insert_n(size: usize, b: &mut Bencher) {
@@ -71,11 +72,6 @@ fn ordmap_insert_n(size: usize, b: &mut Bencher) {
             m = m.update(i, i)
         }
     })
-}
-
-#[bench]
-fn ordmap_insert_10(b: &mut Bencher) {
-    ordmap_insert_n(10, b)
 }
 
 #[bench]
@@ -99,11 +95,6 @@ fn ordmap_insert_mut_n(size: usize, b: &mut Bencher) {
 }
 
 #[bench]
-fn ordmap_insert_mut_10(b: &mut Bencher) {
-    ordmap_insert_mut_n(10, b)
-}
-
-#[bench]
 fn ordmap_insert_mut_100(b: &mut Bencher) {
     ordmap_insert_mut_n(100, b)
 }
@@ -116,6 +107,11 @@ fn ordmap_insert_mut_1000(b: &mut Bencher) {
 #[bench]
 fn ordmap_insert_mut_10000(b: &mut Bencher) {
     ordmap_insert_mut_n(10000, b)
+}
+
+#[bench]
+fn ordmap_insert_mut_100000(b: &mut Bencher) {
+    ordmap_insert_mut_n(100000, b)
 }
 
 fn ordmap_remove_n(size: usize, b: &mut Bencher) {
@@ -131,11 +127,6 @@ fn ordmap_remove_n(size: usize, b: &mut Bencher) {
 }
 
 #[bench]
-fn ordmap_remove_10(b: &mut Bencher) {
-    ordmap_remove_n(10, b)
-}
-
-#[bench]
 fn ordmap_remove_100(b: &mut Bencher) {
     ordmap_remove_n(100, b)
 }
@@ -143,6 +134,11 @@ fn ordmap_remove_100(b: &mut Bencher) {
 #[bench]
 fn ordmap_remove_1000(b: &mut Bencher) {
     ordmap_remove_n(1000, b)
+}
+
+#[bench]
+fn ordmap_remove_10000(b: &mut Bencher) {
+    ordmap_remove_n(10000, b)
 }
 
 fn ordmap_remove_mut_n(size: usize, b: &mut Bencher) {
@@ -158,11 +154,6 @@ fn ordmap_remove_mut_n(size: usize, b: &mut Bencher) {
 }
 
 #[bench]
-fn ordmap_remove_mut_10(b: &mut Bencher) {
-    ordmap_remove_mut_n(10, b)
-}
-
-#[bench]
 fn ordmap_remove_mut_100(b: &mut Bencher) {
     ordmap_remove_mut_n(100, b)
 }
@@ -170,6 +161,11 @@ fn ordmap_remove_mut_100(b: &mut Bencher) {
 #[bench]
 fn ordmap_remove_mut_1000(b: &mut Bencher) {
     ordmap_remove_mut_n(1000, b)
+}
+
+#[bench]
+fn ordmap_remove_mut_10000(b: &mut Bencher) {
+    ordmap_remove_mut_n(10000, b)
 }
 
 #[bench]
@@ -206,11 +202,6 @@ fn ordmap_insert_once_n(size: usize, b: &mut Bencher) {
 }
 
 #[bench]
-fn ordmap_insert_once_10(b: &mut Bencher) {
-    ordmap_insert_once_n(10, b)
-}
-
-#[bench]
 fn ordmap_insert_once_100(b: &mut Bencher) {
     ordmap_insert_once_n(100, b)
 }
@@ -233,11 +224,6 @@ fn ordmap_remove_once_n(size: usize, b: &mut Bencher) {
 }
 
 #[bench]
-fn ordmap_remove_once_10(b: &mut Bencher) {
-    ordmap_remove_once_n(10, b)
-}
-
-#[bench]
 fn ordmap_remove_once_100(b: &mut Bencher) {
     ordmap_remove_once_n(100, b)
 }
@@ -252,16 +238,16 @@ fn ordmap_remove_once_10000(b: &mut Bencher) {
     ordmap_remove_once_n(10000, b)
 }
 
+#[bench]
+fn ordmap_remove_once_100000(b: &mut Bencher) {
+    ordmap_remove_once_n(100000, b)
+}
+
 fn ordmap_lookup_once_n(size: usize, b: &mut Bencher) {
     let keys = random_keys(size + 1);
     let key = keys[0];
     let map: OrdMap<i64, i64> = OrdMap::from_iter(keys.into_iter().map(|i| (i, i)));
     b.iter(|| map.get(&key))
-}
-
-#[bench]
-fn ordmap_lookup_once_10(b: &mut Bencher) {
-    ordmap_lookup_once_n(10, b)
 }
 
 #[bench]
@@ -279,15 +265,15 @@ fn ordmap_lookup_once_10000(b: &mut Bencher) {
     ordmap_lookup_once_n(10000, b)
 }
 
+#[bench]
+fn ordmap_lookup_once_100000(b: &mut Bencher) {
+    ordmap_lookup_once_n(100000, b)
+}
+
 fn ordmap_iter(size: usize, b: &mut Bencher) {
     let keys = random_keys(size);
     let m: OrdMap<i64, i64> = OrdMap::from_iter(keys.into_iter().map(|i| (i, 1)));
     b.iter(|| for _ in m.iter() {})
-}
-
-#[bench]
-fn ordmap_iter_10(b: &mut Bencher) {
-    ordmap_iter(10, b)
 }
 
 #[bench]
@@ -312,11 +298,6 @@ fn ordmap_range_iter(size: usize, b: &mut Bencher) {
 }
 
 #[bench]
-fn ordmap_range_iter_10(b: &mut Bencher) {
-    ordmap_range_iter(10, b)
-}
-
-#[bench]
 fn ordmap_range_iter_100(b: &mut Bencher) {
     ordmap_range_iter(100, b)
 }
@@ -329,4 +310,9 @@ fn ordmap_range_iter_1000(b: &mut Bencher) {
 #[bench]
 fn ordmap_range_iter_10000(b: &mut Bencher) {
     ordmap_range_iter(10000, b)
+}
+
+#[bench]
+fn ordmap_range_iter_100000(b: &mut Bencher) {
+    ordmap_range_iter(100000, b)
 }

--- a/fuzz/fuzz_targets/ordset.rs
+++ b/fuzz/fuzz_targets/ordset.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeSet as NatSet;
 use std::fmt::Debug;
-use std::ops::Range;
+use std::ops::Bound;
 
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
@@ -10,10 +10,18 @@ use libfuzzer_sys::fuzz_target;
 use imbl::OrdSet;
 
 #[derive(Arbitrary, Debug)]
+enum NextAction {
+    Fwd,
+    Bwd,
+    BwdFwd,
+    FwdBwd,
+}
+
+#[derive(Arbitrary, Debug)]
 enum Action<A: Clone + PartialOrd> {
     Insert(A),
     Remove(A),
-    Range(Range<A>),
+    Range((Bound<A>, Bound<A>), NextAction),
 }
 
 fuzz_target!(|actions: Vec<Action<u32>>| {
@@ -22,39 +30,59 @@ fuzz_target!(|actions: Vec<Action<u32>>| {
     for action in actions {
         match action {
             Action::Insert(value) => {
-                let len = nat.len() + if nat.contains(&value) { 0 } else { 1 };
                 nat.insert(value);
                 set.insert(value);
-                assert_eq!(len, set.len());
             }
             Action::Remove(value) => {
-                let len = nat.len() - if nat.contains(&value) { 1 } else { 0 };
                 nat.remove(&value);
                 set.remove(&value);
-                assert_eq!(len, set.len());
             }
-            Action::Range(range) => {
+            Action::Range(range, na) => {
                 assert_eq!(set.get_min(), nat.first());
                 assert_eq!(set.get_max(), nat.last());
-                assert_eq!(set.get_next(&range.start), nat.range(range.start..).next());
-                assert_eq!(set.get_prev(&range.start), nat.range(..=range.start).last());
-
-                let mut set_it = set.range(range.clone());
-                let mut nat_it = nat.range(range.clone());
-                loop {
-                    let (a, b) = (set_it.next(), nat_it.next());
-                    assert_eq!(a, b);
-                    if a.is_none() {
-                        break;
+                match (range.0, range.1) {
+                    (Bound::Included(v) | Bound::Excluded(v), ..)
+                    | (.., Bound::Included(v) | Bound::Excluded(v)) => {
+                        assert_eq!(set.get_next(&v), nat.range(v..).next());
+                        assert_eq!(set.get_prev(&v), nat.range(..=v).last());
+                        assert_eq!(set.get(&v), nat.get(&v));
                     }
+                    _ => {}
                 }
-                let range = range.start..=range.end;
+                // std Btree panics if the range end isn't >= range start
+                // but OrdSet returns an empty iterator
+                let valid_std = match (range.0, range.1) {
+                    (Bound::Included(v), Bound::Included(w)) => v <= w,
+                    (Bound::Excluded(v), Bound::Excluded(w))
+                    | (Bound::Included(v), Bound::Excluded(w))
+                    | (Bound::Excluded(v), Bound::Included(w)) => v < w,
+                    _ => true,
+                };
+                if !valid_std {
+                    assert_eq!(set.range(range).count(), 0);
+                    assert_eq!(set.range(range).rev().count(), 0);
+                    continue;
+                }
+
                 let mut set_it = set.range(range.clone());
                 let mut nat_it = nat.range(range);
                 loop {
-                    let (a, b) = (set_it.next(), nat_it.next());
+                    let (a, b) = match na {
+                        NextAction::Fwd => (set_it.next(), nat_it.next()),
+                        NextAction::Bwd => (set_it.next_back(), nat_it.next_back()),
+                        NextAction::BwdFwd => {
+                            assert_eq!(set_it.next_back(), nat_it.next_back());
+                            (set_it.next(), nat_it.next())
+                        }
+                        NextAction::FwdBwd => {
+                            assert_eq!(set_it.next(), nat_it.next());
+                            (set_it.next_back(), nat_it.next_back())
+                        }
+                    };
                     assert_eq!(a, b);
                     if a.is_none() {
+                        assert_eq!(set_it.next(), None);
+                        assert_eq!(set_it.next_back(), None);
                         break;
                     }
                 }
@@ -64,9 +92,6 @@ fuzz_target!(|actions: Vec<Action<u32>>| {
     }
     assert_eq!(OrdSet::<_>::from(nat.clone()), set);
     assert_eq!(OrdSet::<_>::from_iter(nat.iter().cloned()), set);
-    for (a, b) in set.range(..).zip(nat.range(..)) {
-        assert_eq!(a, b);
-    }
     for (a, b) in set.iter().zip(&nat) {
         assert_eq!(a, b);
     }

--- a/fuzz/fuzz_targets/ordset.rs
+++ b/fuzz/fuzz_targets/ordset.rs
@@ -90,6 +90,7 @@ fuzz_target!(|actions: Vec<Action<u32>>| {
         }
         assert_eq!(nat.len(), set.len());
     }
+    set.check_sane();
     assert_eq!(OrdSet::<_>::from(nat.clone()), set);
     assert_eq!(OrdSet::<_>::from_iter(nat.iter().cloned()), set);
     for (a, b) in set.iter().zip(&nat) {

--- a/proptest-regressions/ord/map.txt
+++ b/proptest-regressions/ord/map.txt
@@ -4,5 +4,3 @@
 #
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
-xs 888006417 2608449019 3789353629 478040202 # shrinks to ref m = {0: 0}
-cc 4d17a23bdf75385eeef3b52975b400b254cb7df841feaf5a362c8b046f5d8ac2 # shrinks to ref map1 = {20948: 0}, ref map2 = {0: 0, 20948: -1}

--- a/proptest-regressions/tests/ordset.txt
+++ b/proptest-regressions/tests/ordset.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc ad212dea44eb83bbfd86396a2e0f9460ecb93f6b1a2644bc700ffc317638a37a # shrinks to actions = let mut set = OrdSet::new(); set.insert(0); let expected = vec![0]; assert_eq!(OrdSet::from(expected), set); 
+cc 7742c112f7a708c9b28d8e61f536aa5e46ed1109e36636108d844f9bc902d3a7 # shrinks to actions = let mut set = OrdSet::new(); set.insert(0); set.insert(1); set.insert(2); set.insert(3); set.insert(4); set.insert(5); set.insert(6); let expected = vec![0, 1, 2, 3, 4, 5, 6]; assert_eq!(OrdSet::from(expected), set); 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ pub(crate) const VECTOR_CHUNK_SIZE: usize = 64;
 /// The branching factor of B-trees
 // Must be an even number!
 #[cfg(feature = "small-chunks")]
-pub(crate) const ORD_CHUNK_SIZE: usize = 4;
+pub(crate) const ORD_CHUNK_SIZE: usize = 6; // Value chosen improve test coverage
 #[cfg(not(feature = "small-chunks"))]
 pub(crate) const ORD_CHUNK_SIZE: usize = 64;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ pub(crate) const VECTOR_CHUNK_SIZE: usize = 64;
 /// The branching factor of B-trees
 // Must be an even number!
 // Value if 6 chosen improve test coverage, specifically
-// so that both deletion node merging and rebalancing are tested. 
+// so that both deletion node merging and rebalancing are tested.
 #[cfg(feature = "small-chunks")]
 pub(crate) const ORD_CHUNK_SIZE: usize = 6;
 #[cfg(not(feature = "small-chunks"))]

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,8 +10,10 @@ pub(crate) const VECTOR_CHUNK_SIZE: usize = 64;
 
 /// The branching factor of B-trees
 // Must be an even number!
+// Value if 6 chosen improve test coverage, specifically
+// so that both deletion node merging and rebalancing are tested. 
 #[cfg(feature = "small-chunks")]
-pub(crate) const ORD_CHUNK_SIZE: usize = 6; // Value chosen improve test coverage
+pub(crate) const ORD_CHUNK_SIZE: usize = 6;
 #[cfg(not(feature = "small-chunks"))]
 pub(crate) const ORD_CHUNK_SIZE: usize = 64;
 

--- a/src/nodes/btree.rs
+++ b/src/nodes/btree.rs
@@ -3,7 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::borrow::Borrow;
-use std::cmp::Ordering;
+use std::collections::VecDeque;
+use std::iter::FromIterator;
 use std::mem;
 use std::ops::{Bound, RangeBounds};
 
@@ -11,1258 +12,529 @@ use archery::{SharedPointer, SharedPointerKind};
 use imbl_sized_chunks::Chunk;
 
 pub(crate) use crate::config::ORD_CHUNK_SIZE as NODE_SIZE;
-use crate::util::clone_ref;
 
-use self::Insert::*;
-use self::InsertAction::*;
-
-const MEDIAN: usize = (NODE_SIZE + 1) >> 1;
+const MEDIAN: usize = NODE_SIZE / 2;
+const THIRD: usize = NODE_SIZE / 3;
 const NUM_CHILDREN: usize = NODE_SIZE + 1;
 
-pub trait BTreeValue {
-    type Key;
-    fn ptr_eq(&self, other: &Self) -> bool;
-    fn search_key<BK>(slice: &[Self], key: &BK) -> Result<usize, usize>
+/// A node in a `B+Tree`.
+#[derive(Debug)]
+pub(crate) enum Node<K, V, P: SharedPointerKind> {
+    Branch(Branch<K, V, P>),
+    Leaf(Leaf<K, V>),
+}
+
+impl<K, V, P: SharedPointerKind> Node<K, V, P> {
+    pub(crate) fn unit(key: K, value: V) -> Self {
+        Node::Leaf(Leaf {
+            keys: Chunk::unit((key, value)),
+        })
+    }
+
+    fn level(&self) -> usize {
+        match self {
+            Node::Branch(branch) => branch.level,
+            Node::Leaf(_) => 0,
+        }
+    }
+}
+
+/// A branch node in a `B+Tree`.
+#[derive(Debug)]
+pub(crate) struct Branch<K, V, P: SharedPointerKind> {
+    keys: Chunk<K, NODE_SIZE>,
+    children: Chunk<SharedPointer<Node<K, V, P>, P>, NUM_CHILDREN>,
+    /// The level of the node in the tree, leaves are implicitly the level 0.
+    level: usize,
+}
+
+impl<K, V, P: SharedPointerKind> Branch<K, V, P> {
+    pub(crate) fn pop_single_child(&mut self) -> Option<SharedPointer<Node<K, V, P>, P>> {
+        if self.children.len() == 1 {
+            debug_assert_eq!(self.keys.len(), 0);
+            return Some(self.children.pop_back());
+        }
+        None
+    }
+}
+
+/// A leaf node in a `B+Tree`.
+#[derive(Debug)]
+pub(crate) struct Leaf<K, V> {
+    keys: Chunk<(K, V), NODE_SIZE>,
+}
+
+impl<K: Ord + Clone, V: Clone, P: SharedPointerKind> Node<K, V, P> {
+    /// Removes a key from the node or its children.
+    /// Returns `true` if the node is underflowed and should be rebalanced.
+    pub(crate) fn remove<BK>(&mut self, key: &BK, removed: &mut Option<(K, V)>) -> bool
     where
         BK: Ord + ?Sized,
-        Self: Sized,
-        Self::Key: Borrow<BK>;
-    fn search_value(slice: &[Self], value: &Self) -> Result<usize, usize>
-    where
-        Self: Sized;
-    fn cmp_keys<BK>(&self, other: &BK) -> Ordering
-    where
-        BK: Ord + ?Sized,
-        Self::Key: Borrow<BK>;
-    fn cmp_values(&self, other: &Self) -> Ordering;
-}
-
-/// A node in a `BTree`.
-///
-/// A node is either internal, or a leaf. Leaf nodes have `None` for every child, and internal
-/// nodes have `Some(_)` for every child. There will never be a mixture of `None`s and `Some`s.
-///
-/// The `children` array is never empty, and always has exactly one more element than `keys`. The
-/// empty tree has no keys, and a single `None` child.
-pub(crate) struct Node<A, P: SharedPointerKind> {
-    keys: Chunk<A, NODE_SIZE>,
-    children: Chunk<Option<SharedPointer<Node<A, P>, P>>, NUM_CHILDREN>,
-}
-
-pub(crate) enum Insert<A, P: SharedPointerKind> {
-    Added,
-    Replaced(A),
-    Split(Node<A, P>, A, Node<A, P>),
-}
-
-enum InsertAction<A, P: SharedPointerKind> {
-    AddedAction,
-    ReplacedAction(A),
-    InsertAt,
-    InsertSplit(Node<A, P>, A, Node<A, P>),
-}
-
-/// The result of a remove operation.
-pub(crate) enum Remove<A, P: SharedPointerKind> {
-    /// The key to remove was not found in the tree; nothing changed.
-    NoChange,
-    /// The key was found and removed: here it is.
-    Removed(A),
-    /// The key was found, and the root node of the tree was modified: here is the found key, and
-    /// the new root node.
-    Update(A, Node<A, P>),
-}
-
-enum Boundary {
-    Lowest,
-    Highest,
-}
-
-enum RemoveAction {
-    DeleteAt(usize),
-    PullUp(Boundary, usize, usize),
-    Merge(usize),
-    StealFromLeft(usize),
-    StealFromRight(usize),
-    MergeFirst(usize),
-    ContinueDown(usize),
-}
-
-impl<A, P> Clone for Node<A, P>
-where
-    A: Clone,
-    P: SharedPointerKind,
-{
-    fn clone(&self) -> Self {
-        Node {
-            keys: self.keys.clone(),
-            children: self.children.clone(),
-        }
-    }
-}
-
-impl<A, P: SharedPointerKind> Default for Node<A, P> {
-    fn default() -> Self {
-        Node {
-            keys: Chunk::new(),
-            children: Chunk::unit(None),
-        }
-    }
-}
-
-impl<A, P: SharedPointerKind> Node<A, P> {
-    #[inline]
-    fn has_room(&self) -> bool {
-        self.keys.len() < NODE_SIZE
-    }
-
-    /// This name is slightly misleading, because we actually check whether this node is the
-    /// minimum allowed size (for a non-root node).
-    #[inline]
-    fn too_small(&self) -> bool {
-        self.keys.len() < MEDIAN
-    }
-
-    #[inline]
-    pub(crate) fn unit(value: A) -> Self {
-        Node {
-            keys: Chunk::unit(value),
-            children: Chunk::pair(None, None),
+        K: Borrow<BK>,
+    {
+        match self {
+            Node::Branch(branch) => {
+                let i = branch
+                    .keys
+                    .binary_search_by(|k| k.borrow().cmp(key))
+                    .map(|x| x + 1)
+                    .unwrap_or_else(|x| x);
+                let child = &mut branch.children[i];
+                if SharedPointer::make_mut(child).remove(key, removed) {
+                    Self::branch_rebalance_children(branch, i);
+                }
+                // Underflow if the branch is < 1/2 full. Since the branches are relatively
+                // rarely rebalanced (given relaxed leaf underflow), we can afford to be
+                // a bit more conservative here.
+                branch.keys.len() < MEDIAN
+            }
+            Node::Leaf(leaf) => {
+                if let Ok(i) = leaf.keys.binary_search_by(|(k, _)| k.borrow().cmp(key)) {
+                    *removed = Some(leaf.keys.remove(i));
+                }
+                // Underflow if the leaf is < 1/3 full. This relaxed underflow (vs. 1/2 full) is
+                // useful to prevent degenerate cases where a random insert/remove workload will
+                // constantly merge/split a leaf.
+                leaf.keys.len() < THIRD
+            }
         }
     }
 
-    #[inline]
-    pub(crate) fn new_from_split(left: Node<A, P>, median: A, right: Node<A, P>) -> Self {
-        Node {
-            keys: Chunk::unit(median),
-            children: Chunk::pair(
-                Some(SharedPointer::new(left)),
-                Some(SharedPointer::new(right)),
-            ),
+    #[cold]
+    pub(crate) fn branch_rebalance_children(branch: &mut Branch<K, V, P>, underflow_idx: usize) {
+        let left_idx = underflow_idx.saturating_sub(1);
+        let (left, mid, right) = match &branch.children[left_idx..] {
+            [left, mid, right, ..] => (&**left, &**mid, Some(&**right)),
+            [left, mid, ..] => (&**left, &**mid, None),
+            _ => return,
+        };
+        // Prefer merging two sibling children if we can fit them into a single node.
+        // But also try to rebalance is the smallest child is small (< 1/3), to amortize the cost of rebalancing.
+        // Since we prefer merging, for rebalancing to apply the the largest child will be least 2/3 full,
+        // which results in two at least half full nodes after rebalancing.
+        match (left, mid, right) {
+            (Node::Leaf(left), Node::Leaf(mid), _)
+                if left.keys.len() + mid.keys.len() <= NODE_SIZE =>
+            {
+                Self::merge_leaves(branch, left_idx, false);
+            }
+            (_, Node::Leaf(mid), Some(Node::Leaf(right)))
+                if mid.keys.len() + right.keys.len() <= NODE_SIZE =>
+            {
+                Self::merge_leaves(branch, left_idx + 1, true);
+            }
+            (Node::Leaf(left), Node::Leaf(mid), _)
+                if mid.keys.len().min(left.keys.len()) < THIRD =>
+            {
+                Self::rebalance_leaves(branch, left_idx);
+            }
+            (_, Node::Leaf(mid), Some(Node::Leaf(right)))
+                if mid.keys.len().min(right.keys.len()) < THIRD =>
+            {
+                Self::rebalance_leaves(branch, left_idx + 1);
+            }
+            (Node::Branch(left), Node::Branch(mid), _)
+                if left.keys.len() + mid.keys.len() < NODE_SIZE =>
+            {
+                Self::merge_branches(branch, left_idx, false);
+            }
+            (_, Node::Branch(mid), Some(Node::Branch(right)))
+                if mid.keys.len() + right.keys.len() < NODE_SIZE =>
+            {
+                Self::merge_branches(branch, left_idx + 1, true);
+            }
+            (Node::Branch(left), Node::Branch(mid), _)
+                if mid.keys.len().min(left.keys.len()) < THIRD =>
+            {
+                Self::rebalance_branches(branch, left_idx);
+            }
+            (_, Node::Branch(mid), Some(Node::Branch(right)))
+                if mid.keys.len().min(right.keys.len()) < THIRD =>
+            {
+                Self::rebalance_branches(branch, left_idx + 1);
+            }
+            _ => (),
         }
     }
 
-    pub(crate) fn min(&self) -> Option<&A> {
-        match self.children.first().unwrap() {
-            None => self.keys.first(),
-            Some(ref child) => child.min(),
-        }
-    }
-
-    pub(crate) fn max(&self) -> Option<&A> {
-        match self.children.last().unwrap() {
-            None => self.keys.last(),
-            Some(ref child) => child.max(),
-        }
-    }
-}
-
-impl<A: BTreeValue, P: SharedPointerKind> Node<A, P> {
-    // Checks that this tree is balanced, and returns its depth.
-    #[cfg(test)]
-    pub(crate) fn check_depth(&self) -> usize {
-        if self.children.is_empty() {
-            // This is an empty tree.
-            0
-        } else if self.children[0].is_none() {
-            // This is a leaf node.
-            1
+    fn merge_leaves(branch: &mut Branch<K, V, P>, left_idx: usize, keep_left: bool) {
+        let [left, right, ..] = &mut branch.children[left_idx..] else {
+            unreachable!()
+        };
+        if keep_left {
+            let left = SharedPointer::make_mut(left);
+            let (Node::Leaf(left), Node::Leaf(right)) = (left, &**right) else {
+                unreachable!()
+            };
+            left.keys.extend(right.keys.iter().cloned());
         } else {
-            let mut depth = None;
-            for c in self.children.iter() {
-                let d = c.as_ref().unwrap().check_depth();
-                assert!(depth.is_none() || depth == Some(d));
-                depth = Some(d);
+            let right = SharedPointer::make_mut(right);
+            let (Node::Leaf(left), Node::Leaf(right)) = (&**left, right) else {
+                unreachable!()
+            };
+            right.keys.insert_from(0, left.keys.iter().cloned());
+        }
+        branch.keys.remove(left_idx);
+        branch.children.remove(left_idx + (keep_left as usize));
+        debug_assert_eq!(branch.keys.len() + 1, branch.children.len());
+    }
+
+    /// Rebalance the leaves by moving keys from the largest leaf to the smallest leaf so they end up
+    /// with the same number of keys.
+    fn rebalance_leaves(branch: &mut Branch<K, V, P>, left_idx: usize) {
+        let [left, right, ..] = &mut branch.children[left_idx..] else {
+            unreachable!()
+        };
+        let (Node::Leaf(left), Node::Leaf(right)) = (
+            SharedPointer::make_mut(left),
+            SharedPointer::make_mut(right),
+        ) else {
+            unreachable!()
+        };
+        let num_to_move = left.keys.len().abs_diff(right.keys.len()) / 2;
+        if num_to_move == 0 {
+            return;
+        }
+        if left.keys.len() > right.keys.len() {
+            right.keys.drain_from_back(&mut left.keys, num_to_move);
+        } else {
+            left.keys.drain_from_front(&mut right.keys, num_to_move);
+        }
+        branch.keys[left_idx] = right.keys.first().unwrap().0.clone();
+        debug_assert_ne!(left.keys.len(), 0);
+        debug_assert_ne!(right.keys.len(), 0);
+    }
+
+    fn rebalance_branches(branch: &mut Branch<K, V, P>, left_idx: usize) {
+        let [left, right, ..] = &mut branch.children[left_idx..] else {
+            unreachable!()
+        };
+        let (Node::Branch(left), Node::Branch(right)) = (
+            SharedPointer::make_mut(left),
+            SharedPointer::make_mut(right),
+        ) else {
+            unreachable!()
+        };
+        let num_to_move = left.keys.len().abs_diff(right.keys.len()) / 2;
+        if num_to_move == 0 {
+            return;
+        }
+        let separator = &mut branch.keys[left_idx];
+        if left.keys.len() > right.keys.len() {
+            right.keys.push_front(separator.clone());
+            right.keys.drain_from_back(&mut left.keys, num_to_move - 1);
+            *separator = left.keys.pop_back();
+            right
+                .children
+                .drain_from_back(&mut left.children, num_to_move);
+        } else {
+            left.keys.push_back(separator.clone());
+            left.keys.drain_from_front(&mut right.keys, num_to_move - 1);
+            *separator = right.keys.pop_front();
+            left.children
+                .drain_from_front(&mut right.children, num_to_move);
+        }
+        debug_assert_ne!(left.keys.len(), 0);
+        debug_assert_eq!(left.children.len(), left.keys.len() + 1);
+        debug_assert_ne!(right.keys.len(), 0);
+        debug_assert_eq!(right.children.len(), right.keys.len() + 1);
+    }
+
+    fn merge_branches(branch: &mut Branch<K, V, P>, left_idx: usize, keep_left: bool) {
+        let [left, right, ..] = &mut branch.children[left_idx..] else {
+            unreachable!()
+        };
+        let separator = branch.keys.remove(left_idx);
+        if keep_left {
+            let left = SharedPointer::make_mut(left);
+            let (Node::Branch(left), Node::Branch(right)) = (left, &**right) else {
+                unreachable!()
+            };
+            left.keys.push_back(separator);
+            left.keys.extend(right.keys.iter().cloned());
+            left.children.extend(right.children.iter().cloned());
+        } else {
+            let right = SharedPointer::make_mut(right);
+            let (Node::Branch(left), Node::Branch(right)) = (&**left, right) else {
+                unreachable!()
+            };
+            right.keys.push_front(separator);
+            right.keys.insert_from(0, left.keys.iter().cloned());
+            right.children.insert_from(0, left.children.iter().cloned());
+        }
+        branch.children.remove(left_idx + (keep_left as usize));
+        debug_assert_eq!(branch.keys.len() + 1, branch.children.len());
+    }
+
+    pub(crate) fn insert(&mut self, key: K, value: V) -> InsertAction<K, V, P> {
+        match self {
+            Node::Branch(branch) => {
+                let i = branch
+                    .keys
+                    .binary_search(&key)
+                    .map(|x| x + 1)
+                    .unwrap_or_else(|x| x);
+                match SharedPointer::make_mut(&mut branch.children[i]).insert(key, value) {
+                    InsertAction::Split(new_key, new_node) if branch.keys.len() >= NODE_SIZE => {
+                        Self::split_branch_insert(branch, i, new_key, new_node)
+                    }
+                    InsertAction::Split(separator, new_node) => {
+                        branch.keys.insert(i, separator);
+                        branch.children.insert(i + 1, new_node);
+                        InsertAction::Inserted
+                    }
+                    action => action,
+                }
             }
-            depth.unwrap()
+            Node::Leaf(leaf) => match leaf.keys.binary_search_by(|(k, _)| k.cmp(&key)) {
+                Ok(i) => {
+                    let (k, v) = mem::replace(&mut leaf.keys[i], (key, value));
+                    InsertAction::Replaced(k, v)
+                }
+                Err(i) if leaf.keys.len() >= NODE_SIZE => {
+                    Self::split_leaf_insert(leaf, i, key, value)
+                }
+                Err(i) => {
+                    leaf.keys.insert(i, (key, value));
+                    InsertAction::Inserted
+                }
+            },
         }
     }
 
-    // Checks that the keys are in the right order.
-    #[cfg(test)]
-    pub(crate) fn check_order(&self) {
-        fn recurse<A: BTreeValue, P: SharedPointerKind>(node: &Node<A, P>) -> (&A, &A) {
-            for window in node.keys.windows(2) {
-                assert!(window[0].cmp_values(&window[1]) == Ordering::Less);
-            }
-            if node.is_leaf() {
-                (node.keys.first().unwrap(), node.keys.last().unwrap())
+    #[cold]
+    fn split_branch_insert(
+        branch: &mut Branch<K, V, P>,
+        i: usize,
+        new_key: K,
+        new_node: SharedPointer<Node<K, V, P>, P>,
+    ) -> InsertAction<K, V, P> {
+        let split_idx = MEDIAN + (i > MEDIAN) as usize;
+        let mut right_keys = branch.keys.split_off(split_idx);
+        let split_idx = MEDIAN + (i >= MEDIAN) as usize;
+        let mut right_children = branch.children.split_off(split_idx);
+        let separator = if i == MEDIAN {
+            right_children.push_front(new_node.clone());
+            new_key
+        } else {
+            if i < MEDIAN {
+                branch.keys.insert(i, new_key);
+                branch.children.insert(i + 1, new_node);
             } else {
-                for i in 0..node.keys.len() {
-                    let left_max = recurse(node.children[i].as_ref().unwrap()).1;
-                    let right_min = recurse(node.children[i + 1].as_ref().unwrap()).0;
-                    assert!(node.keys[i].cmp_values(left_max) == Ordering::Greater);
-                    assert!(node.keys[i].cmp_values(right_min) == Ordering::Less);
-                }
-                (
-                    recurse(node.children.first().unwrap().as_ref().unwrap()).0,
-                    recurse(node.children.last().unwrap().as_ref().unwrap()).1,
-                )
+                right_keys.insert(i - (MEDIAN + 1), new_key);
+                right_children.insert(i - (MEDIAN + 1) + 1, new_node);
             }
-        }
-        if !self.keys.is_empty() {
-            recurse(self);
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn check_size(&self) {
-        fn recurse<A: BTreeValue, P: SharedPointerKind>(node: &Node<A, P>) {
-            assert!(node.keys.len() + 1 == node.children.len());
-            assert!(node.keys.len() + 1 >= MEDIAN);
-            if !node.is_leaf() {
-                for c in &node.children {
-                    recurse(c.as_ref().unwrap());
-                }
-            }
-        }
-        if !self.is_leaf() {
-            for c in &self.children {
-                recurse(c.as_ref().unwrap());
-            }
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn check_sane(&self) {
-        self.check_depth();
-        self.check_order();
-        self.check_size();
-    }
-
-    fn child_contains<BK>(&self, index: usize, key: &BK) -> bool
-    where
-        BK: Ord + ?Sized,
-        A::Key: Borrow<BK>,
-    {
-        if let Some(Some(ref child)) = self.children.get(index) {
-            child.lookup(key).is_some()
-        } else {
-            false
-        }
-    }
-
-    pub(crate) fn lookup<BK>(&self, key: &BK) -> Option<&A>
-    where
-        BK: Ord + ?Sized,
-        A::Key: Borrow<BK>,
-    {
-        if self.keys.is_empty() {
-            return None;
-        }
-        // Perform a binary search, resulting in either a match or
-        // the index of the first higher key, meaning we search the
-        // child to the left of it.
-        match A::search_key(&self.keys, key) {
-            Ok(index) => Some(&self.keys[index]),
-            Err(index) => match self.children[index] {
-                None => None,
-                Some(ref node) => node.lookup(key),
-            },
-        }
-    }
-
-    pub(crate) fn lookup_mut<BK>(&mut self, key: &BK) -> Option<&mut A>
-    where
-        A: Clone,
-        BK: Ord + ?Sized,
-        A::Key: Borrow<BK>,
-    {
-        if self.keys.is_empty() {
-            return None;
-        }
-        // Perform a binary search, resulting in either a match or
-        // the index of the first higher key, meaning we search the
-        // child to the left of it.
-        match A::search_key(&self.keys, key) {
-            Ok(index) => Some(&mut self.keys[index]),
-            Err(index) => match self.children[index] {
-                None => None,
-                Some(ref mut child_ref) => {
-                    let child = SharedPointer::make_mut(child_ref);
-                    child.lookup_mut(key)
-                }
-            },
-        }
-    }
-
-    pub(crate) fn lookup_prev<BK>(&self, key: &BK) -> Option<&A>
-    where
-        BK: Ord + ?Sized,
-        A::Key: Borrow<BK>,
-    {
-        if self.keys.is_empty() {
-            return None;
-        }
-        match A::search_key(&self.keys, key) {
-            Ok(index) => Some(&self.keys[index]),
-            Err(index) => self.children[index]
-                .as_ref()
-                .and_then(|node| node.lookup_prev(key))
-                // If we haven't found our search key yet, it isn't in any child subtree of ours.
-                // That means that if index == 0 then we have no predecessor for the search key,
-                // and if index > 0 then the predecessor is our key at index - 1.
-                .or_else(|| index.checked_sub(1).and_then(|i| self.keys.get(i))),
-        }
-    }
-
-    pub(crate) fn lookup_next<BK>(&self, key: &BK) -> Option<&A>
-    where
-        BK: Ord + ?Sized,
-        A::Key: Borrow<BK>,
-    {
-        if self.keys.is_empty() {
-            return None;
-        }
-        match A::search_key(&self.keys, key) {
-            Ok(index) => Some(&self.keys[index]),
-            Err(index) => self.children[index]
-                .as_ref()
-                .and_then(|node| node.lookup_next(key))
-                // If we don't find the search key in the child subtree, then either our next key
-                // is the search key's successor, or else we don't have a successor in our subtree.
-                .or_else(|| self.keys.get(index)),
-        }
-    }
-
-    pub(crate) fn lookup_prev_mut<BK>(&mut self, key: &BK) -> Option<&mut A>
-    where
-        A: Clone,
-        BK: Ord + ?Sized,
-        A::Key: Borrow<BK>,
-    {
-        if self.keys.is_empty() {
-            return None;
-        }
-        let keys = &mut self.keys;
-        match A::search_key(keys, key) {
-            Ok(index) => Some(&mut keys[index]),
-            Err(index) => self.children[index]
-                .as_mut()
-                .and_then(|node| SharedPointer::make_mut(node).lookup_prev_mut(key))
-                .or_else(|| index.checked_sub(1).and_then(move |i| keys.get_mut(i))),
-        }
-    }
-
-    pub(crate) fn lookup_next_mut<BK>(&mut self, key: &BK) -> Option<&mut A>
-    where
-        A: Clone,
-        BK: Ord + ?Sized,
-        A::Key: Borrow<BK>,
-    {
-        if self.keys.is_empty() {
-            return None;
-        }
-        let keys = &mut self.keys;
-        match A::search_key(keys, key) {
-            Ok(index) => Some(&mut keys[index]),
-            Err(index) => self.children[index]
-                .as_mut()
-                .and_then(|node| SharedPointer::make_mut(node).lookup_next_mut(key))
-                .or_else(move || keys.get_mut(index)),
-        }
-    }
-
-    pub(crate) fn path_first<'a, BK>(
-        &'a self,
-        mut path: Vec<(&'a Node<A, P>, usize)>,
-    ) -> Vec<(&'a Node<A, P>, usize)>
-    where
-        A: 'a,
-        BK: Ord + ?Sized,
-        A::Key: Borrow<BK>,
-    {
-        if self.keys.is_empty() {
-            return Vec::new();
-        }
-        match self.children[0] {
-            None => {
-                path.push((self, 0));
-                path
-            }
-            Some(ref node) => {
-                path.push((self, 0));
-                node.path_first(path)
-            }
-        }
-    }
-
-    pub(crate) fn path_last<'a, BK>(
-        &'a self,
-        mut path: Vec<(&'a Node<A, P>, usize)>,
-    ) -> Vec<(&'a Node<A, P>, usize)>
-    where
-        A: 'a,
-        BK: Ord + ?Sized,
-        A::Key: Borrow<BK>,
-    {
-        if self.keys.is_empty() {
-            return Vec::new();
-        }
-        let end = self.children.len() - 1;
-        match self.children[end] {
-            None => {
-                path.push((self, end - 1));
-                path
-            }
-            Some(ref node) => {
-                path.push((self, end));
-                node.path_last(path)
-            }
-        }
-    }
-
-    pub(crate) fn path_next<'a, BK>(
-        &'a self,
-        key: &BK,
-        mut path: Vec<(&'a Node<A, P>, usize)>,
-    ) -> Vec<(&'a Node<A, P>, usize)>
-    where
-        A: 'a,
-        BK: Ord + ?Sized,
-        A::Key: Borrow<BK>,
-    {
-        if self.keys.is_empty() {
-            return Vec::new();
-        }
-        match A::search_key(&self.keys, key) {
-            Ok(index) => {
-                path.push((self, index));
-                path
-            }
-            Err(index) => match self.children[index] {
-                None => match self.keys.get(index) {
-                    Some(_) => {
-                        path.push((self, index));
-                        path
-                    }
-                    None => {
-                        // go back up to find next
-                        while let Some((node, idx)) = path.last() {
-                            if node.keys.len() == *idx {
-                                path.pop();
-                            } else {
-                                break;
-                            }
-                        }
-                        path
-                    }
-                },
-                Some(ref node) => {
-                    path.push((self, index));
-                    node.path_next(key, path)
-                }
-            },
-        }
-    }
-
-    pub(crate) fn path_prev<'a, BK>(
-        &'a self,
-        key: &BK,
-        mut path: Vec<(&'a Node<A, P>, usize)>,
-    ) -> Vec<(&'a Node<A, P>, usize)>
-    where
-        A: 'a,
-        BK: Ord + ?Sized,
-        A::Key: Borrow<BK>,
-    {
-        if self.keys.is_empty() {
-            return Vec::new();
-        }
-        match A::search_key(&self.keys, key) {
-            Ok(index) => {
-                path.push((self, index));
-                path
-            }
-            Err(index) => match self.children[index] {
-                None if index == 0 => {
-                    // go back up to find prev
-                    while let Some((_, idx)) = path.last_mut() {
-                        if *idx == 0 {
-                            path.pop();
-                        } else {
-                            *idx -= 1;
-                            break;
-                        }
-                    }
-                    path
-                }
-                None => {
-                    path.push((self, index - 1));
-                    path
-                }
-                Some(ref node) => {
-                    path.push((self, index));
-                    node.path_prev(key, path)
-                }
-            },
-        }
-    }
-
-    fn split(
-        &mut self,
-        value: A,
-        ins_left: Option<Node<A, P>>,
-        ins_right: Option<Node<A, P>>,
-    ) -> Insert<A, P> {
-        let left_child = ins_left.map(SharedPointer::new);
-        let right_child = ins_right.map(SharedPointer::new);
-        let index = A::search_value(&self.keys, &value).unwrap_err();
-        let mut left_keys;
-        let mut left_children;
-        let mut right_keys;
-        let mut right_children;
-        let median;
-        match index.cmp(&MEDIAN) {
-            Ordering::Less => {
-                self.children[index] = left_child;
-
-                left_keys = Chunk::from_front(&mut self.keys, index);
-                left_keys.push_back(value);
-                left_keys.drain_from_front(&mut self.keys, MEDIAN - index - 1);
-
-                left_children = Chunk::from_front(&mut self.children, index + 1);
-                left_children.push_back(right_child);
-                left_children.drain_from_front(&mut self.children, MEDIAN - index - 1);
-
-                median = self.keys.pop_front();
-
-                right_keys = Chunk::drain_from(&mut self.keys);
-                right_children = Chunk::drain_from(&mut self.children);
-            }
-            Ordering::Greater => {
-                self.children[index] = left_child;
-
-                left_keys = Chunk::from_front(&mut self.keys, MEDIAN);
-                left_children = Chunk::from_front(&mut self.children, MEDIAN + 1);
-
-                median = self.keys.pop_front();
-
-                right_keys = Chunk::from_front(&mut self.keys, index - MEDIAN - 1);
-                right_keys.push_back(value);
-                right_keys.append(&mut self.keys);
-
-                right_children = Chunk::from_front(&mut self.children, index - MEDIAN);
-                right_children.push_back(right_child);
-                right_children.append(&mut self.children);
-            }
-            Ordering::Equal => {
-                left_keys = Chunk::from_front(&mut self.keys, MEDIAN);
-                left_children = Chunk::from_front(&mut self.children, MEDIAN);
-                left_children.push_back(left_child);
-
-                median = value;
-
-                right_keys = Chunk::drain_from(&mut self.keys);
-                right_children = Chunk::drain_from(&mut self.children);
-                right_children[0] = right_child;
-            }
-        }
-
-        debug_assert!(left_keys.len() == MEDIAN);
-        debug_assert!(left_children.len() == MEDIAN + 1);
-        debug_assert!(right_keys.len() == MEDIAN);
-        debug_assert!(right_children.len() == MEDIAN + 1);
-
-        Split(
-            Node {
-                keys: left_keys,
-                children: left_children,
-            },
-            median,
-            Node {
+            branch.keys.pop_back()
+        };
+        debug_assert_eq!(branch.keys.len(), right_keys.len());
+        debug_assert_eq!(branch.keys.len() + 1, branch.children.len());
+        debug_assert_eq!(right_keys.len() + 1, right_children.len());
+        InsertAction::Split(
+            separator,
+            SharedPointer::new(Node::Branch(Branch {
+                level: branch.level,
                 keys: right_keys,
                 children: right_children,
-            },
+            })),
         )
     }
 
-    fn merge(middle: A, left: Node<A, P>, mut right: Node<A, P>) -> Node<A, P> {
-        let mut keys = left.keys;
-        keys.push_back(middle);
-        keys.append(&mut right.keys);
-        let mut children = left.children;
-        children.append(&mut right.children);
-        Node { keys, children }
-    }
-
-    fn pop_min(&mut self) -> (A, Option<SharedPointer<Node<A, P>, P>>) {
-        let value = self.keys.pop_front();
-        let child = self.children.pop_front();
-        (value, child)
-    }
-
-    fn pop_max(&mut self) -> (A, Option<SharedPointer<Node<A, P>, P>>) {
-        let value = self.keys.pop_back();
-        let child = self.children.pop_back();
-        (value, child)
-    }
-
-    fn push_min(&mut self, child: Option<SharedPointer<Node<A, P>, P>>, value: A) {
-        self.keys.push_front(value);
-        self.children.push_front(child);
-    }
-
-    fn push_max(&mut self, child: Option<SharedPointer<Node<A, P>, P>>, value: A) {
-        self.keys.push_back(value);
-        self.children.push_back(child);
-    }
-
-    fn is_leaf(&self) -> bool {
-        // `children` is never empty, so we can index it.
-        self.children[0].is_none()
-    }
-
-    pub(crate) fn insert(&mut self, value: A) -> Insert<A, P>
-    where
-        A: Clone,
-    {
-        if self.keys.is_empty() {
-            self.keys.push_back(value);
-            self.children.push_back(None);
-            return Insert::Added;
+    #[inline]
+    fn split_leaf_insert(
+        leaf: &mut Leaf<K, V>,
+        i: usize,
+        key: K,
+        value: V,
+    ) -> InsertAction<K, V, P> {
+        let mut right_keys = leaf.keys.split_off(MEDIAN);
+        if i < MEDIAN {
+            leaf.keys.insert(i, (key, value));
+        } else {
+            right_keys.insert(i - MEDIAN, (key, value));
         }
-        let (median, left, right) = match A::search_value(&self.keys, &value) {
-            // Key exists in node
-            Ok(index) => {
-                return Insert::Replaced(mem::replace(&mut self.keys[index], value));
-            }
-            // Key is adjacent to some key in node
-            Err(index) => {
-                let has_room = self.has_room();
-                let action = match self.children[index] {
-                    // No child at location, this is the target node.
-                    None => InsertAt,
-                    // Child at location, pass it on.
-                    Some(ref mut child_ref) => {
-                        let child = SharedPointer::make_mut(child_ref);
-                        match child.insert(value.clone()) {
-                            Insert::Added => AddedAction,
-                            Insert::Replaced(value) => ReplacedAction(value),
-                            Insert::Split(left, median, right) => InsertSplit(left, median, right),
-                        }
-                    }
-                };
-                match action {
-                    ReplacedAction(value) => return Insert::Replaced(value),
-                    AddedAction => {
-                        return Insert::Added;
-                    }
-                    InsertAt => {
-                        if has_room {
-                            self.keys.insert(index, value);
-                            self.children.insert(index + 1, None);
-                            return Insert::Added;
-                        } else {
-                            (value, None, None)
-                        }
-                    }
-                    InsertSplit(left, median, right) => {
-                        if has_room {
-                            self.children[index] = Some(SharedPointer::new(left));
-                            self.keys.insert(index, median);
-                            self.children
-                                .insert(index + 1, Some(SharedPointer::new(right)));
-                            return Insert::Added;
-                        } else {
-                            (median, Some(left), Some(right))
-                        }
-                    }
-                }
-            }
-        };
-        self.split(median, left, right)
+        InsertAction::Split(
+            right_keys.first().unwrap().0.clone(),
+            SharedPointer::new(Node::Leaf(Leaf { keys: right_keys })),
+        )
     }
 
-    pub(crate) fn remove<BK>(&mut self, key: &BK) -> Remove<A, P>
+    pub(crate) fn lookup_mut<BK>(&mut self, key: &BK) -> Option<(&K, &mut V)>
     where
-        A: Clone,
         BK: Ord + ?Sized,
-        A::Key: Borrow<BK>,
+        K: Borrow<BK>,
     {
-        let index = A::search_key(&self.keys, key);
-        self.remove_index(index, Ok(key))
+        match self {
+            Node::Branch(branch) => {
+                let i = branch
+                    .keys
+                    .binary_search_by(|k| k.borrow().cmp(key))
+                    .map(|x| x + 1)
+                    .unwrap_or_else(|x| x);
+                SharedPointer::make_mut(&mut branch.children[i]).lookup_mut(key)
+            }
+            Node::Leaf(leaf) => {
+                let keys = &mut leaf.keys;
+                let i = keys.binary_search_by(|(k, _)| k.borrow().cmp(key)).ok()?;
+                keys.get_mut(i).map(|(k, v)| (&*k, v))
+            }
+        }
     }
 
-    fn remove_target<BK>(&mut self, target: Result<&BK, Boundary>) -> Remove<A, P>
-    where
-        A: Clone,
-        BK: Ord + ?Sized,
-        A::Key: Borrow<BK>,
-    {
-        let index = match target {
-            Ok(key) => A::search_key(&self.keys, key),
-            Err(Boundary::Lowest) => Err(0),
-            Err(Boundary::Highest) => Err(self.keys.len()),
-        };
-        self.remove_index(index, target)
+    pub(crate) fn new_from_split(
+        left: SharedPointer<Self, P>,
+        separator: K,
+        right: SharedPointer<Self, P>,
+    ) -> Self {
+        Node::Branch(Branch {
+            level: left.level() + 1,
+            keys: Chunk::unit(separator),
+            children: Chunk::from_iter([left, right]),
+        })
+    }
+}
+
+impl<K: Ord, V, P: SharedPointerKind> Node<K, V, P> {
+    pub(crate) fn min(&self) -> Option<&(K, V)> {
+        let mut node = self;
+        loop {
+            node = match node {
+                Node::Branch(branch) => &branch.children[0],
+                Node::Leaf(leaf) => return leaf.keys.first(),
+            };
+        }
     }
 
-    fn remove_index<BK>(
-        &mut self,
-        index: Result<usize, usize>,
-        target: Result<&BK, Boundary>,
-    ) -> Remove<A, P>
+    pub(crate) fn max(&self) -> Option<&(K, V)> {
+        let mut node = self;
+        loop {
+            node = match node {
+                Node::Branch(branch) => &branch.children[branch.children.len() - 1],
+                Node::Leaf(leaf) => return leaf.keys.last(),
+            };
+        }
+    }
+
+    pub(crate) fn lookup<BK>(&self, key: &BK) -> Option<&(K, V)>
     where
-        A: Clone,
         BK: Ord + ?Sized,
-        A::Key: Borrow<BK>,
+        K: Borrow<BK>,
     {
-        let action = match index {
-            // Key exists in node, remove it.
-            Ok(index) => {
-                match (&self.children[index], &self.children[index + 1]) {
-                    // If we're a leaf, just delete the entry.
-                    (&None, &None) => RemoveAction::DeleteAt(index),
-                    // First consider pulling either predecessor (from left) or successor (from right).
-                    // otherwise just merge the two small children.
-                    (Some(left), Some(right)) => {
-                        if !left.too_small() {
-                            RemoveAction::PullUp(Boundary::Highest, index, index)
-                        } else if !right.too_small() {
-                            RemoveAction::PullUp(Boundary::Lowest, index, index + 1)
-                        } else {
-                            RemoveAction::Merge(index)
-                        }
-                    }
-                    _ => unreachable!("Branch missing children"),
+        let mut node = self;
+        loop {
+            match node {
+                Node::Branch(branch) => {
+                    let i = branch
+                        .keys
+                        .binary_search_by(|k| k.borrow().cmp(key))
+                        .map(|x| x + 1)
+                        .unwrap_or_else(|x| x);
+                    node = &branch.children[i];
                 }
-            }
-            // Target is adjacent to some key in node
-            Err(index) => match self.children[index] {
-                // We're deading with a leaf node
-                None => match target {
-                    // No child at location means key isn't in map.
-                    Ok(_key) => return Remove::NoChange,
-                    // Looking for the lowest or highest key
-                    Err(Boundary::Lowest) => RemoveAction::DeleteAt(0),
-                    Err(Boundary::Highest) => RemoveAction::DeleteAt(self.keys.len() - 1),
-                },
-                // Child at location, but it's at minimum capacity.
-                Some(ref child) if child.too_small() => {
-                    let left = if index > 0 {
-                        self.children.get(index - 1)
-                    } else {
-                        None
-                    }; // index is usize and can't be negative, best make sure it never is.
-                    match (left, self.children.get(index + 1)) {
-                        // If it has a left sibling with capacity, steal a key from it.
-                        (Some(Some(old_left)), _) if !old_left.too_small() => {
-                            RemoveAction::StealFromLeft(index)
-                        }
-                        // If it has a right sibling with capacity, same as above.
-                        (_, Some(Some(old_right))) if !old_right.too_small() => {
-                            RemoveAction::StealFromRight(index)
-                        }
-                        // If it has neither, we'll have to merge it with a sibling.
-                        // If we have a right sibling, we'll merge with that.
-                        (_, Some(&Some(_))) => RemoveAction::MergeFirst(index),
-                        // If we have a left sibling, we'll merge with that.
-                        (Some(&Some(_)), _) => RemoveAction::MergeFirst(index - 1),
-                        // If none of the above, we're in a bad state.
-                        _ => unreachable!(),
-                    }
+                Node::Leaf(leaf) => {
+                    let keys = &leaf.keys;
+                    let i = keys.binary_search_by(|(k, _)| k.borrow().cmp(key)).ok()?;
+                    return keys.get(i);
                 }
-                // Child at location, and it's big enough, we can recurse down.
-                Some(_) => RemoveAction::ContinueDown(index),
-            },
-        };
-        match action {
-            RemoveAction::DeleteAt(index) => {
-                let pair = self.keys.remove(index);
-                self.children.remove(index);
-                Remove::Removed(pair)
-            }
-            RemoveAction::PullUp(boundary, pull_to, child_index) => {
-                let children = &mut self.children;
-                let mut update = None;
-                let value;
-                if let Some(&mut Some(ref mut child_ref)) = children.get_mut(child_index) {
-                    let child = SharedPointer::make_mut(child_ref);
-                    match child.remove_target(Err(boundary)) {
-                        Remove::NoChange => unreachable!(),
-                        Remove::Removed(pulled_value) => {
-                            value = self.keys.set(pull_to, pulled_value);
-                        }
-                        Remove::Update(pulled_value, new_child) => {
-                            value = self.keys.set(pull_to, pulled_value);
-                            update = Some(new_child);
-                        }
-                    }
-                } else {
-                    unreachable!()
-                }
-                if let Some(new_child) = update {
-                    children[child_index] = Some(SharedPointer::new(new_child));
-                }
-                Remove::Removed(value)
-            }
-            RemoveAction::Merge(index) => {
-                let left = self.children.remove(index).unwrap();
-                let right = self.children[index].take().unwrap();
-                let value = self.keys.remove(index);
-                let mut merged_child = Node::merge(value, clone_ref(left), clone_ref(right));
-                let (removed, new_child) = match merged_child.remove_target(target) {
-                    Remove::NoChange => unreachable!(),
-                    Remove::Removed(removed) => (removed, merged_child),
-                    Remove::Update(removed, updated_child) => (removed, updated_child),
-                };
-                if self.keys.is_empty() {
-                    // If we've depleted the root node, the merged child becomes the root.
-                    Remove::Update(removed, new_child)
-                } else {
-                    self.children[index] = Some(SharedPointer::new(new_child));
-                    Remove::Removed(removed)
-                }
-            }
-            RemoveAction::StealFromLeft(index) => {
-                let mut update = None;
-                let out_value;
-                {
-                    let mut children = self.children.as_mut_slice()[index - 1..=index]
-                        .iter_mut()
-                        .map(|n| n.as_mut().unwrap());
-                    let left = SharedPointer::make_mut(children.next().unwrap());
-                    let child = SharedPointer::make_mut(children.next().unwrap());
-                    // Prepare the rebalanced node.
-                    child.push_min(
-                        left.children.last().unwrap().clone(),
-                        self.keys[index - 1].clone(),
-                    );
-                    match child.remove_target(target) {
-                        Remove::NoChange => {
-                            // Key wasn't there, we need to revert the steal.
-                            child.pop_min();
-                            return Remove::NoChange;
-                        }
-                        Remove::Removed(value) => {
-                            // If we did remove something, we complete the rebalancing.
-                            let (left_value, _) = left.pop_max();
-                            self.keys[index - 1] = left_value;
-                            out_value = value;
-                        }
-                        Remove::Update(value, new_child) => {
-                            // If we did remove something, we complete the rebalancing.
-                            let (left_value, _) = left.pop_max();
-                            self.keys[index - 1] = left_value;
-                            update = Some(new_child);
-                            out_value = value;
-                        }
-                    }
-                }
-                if let Some(new_child) = update {
-                    self.children[index] = Some(SharedPointer::new(new_child));
-                }
-                Remove::Removed(out_value)
-            }
-            RemoveAction::StealFromRight(index) => {
-                let mut update = None;
-                let out_value;
-                {
-                    let mut children = self.children.as_mut_slice()[index..index + 2]
-                        .iter_mut()
-                        .map(|n| n.as_mut().unwrap());
-                    let child = SharedPointer::make_mut(children.next().unwrap());
-                    let right = SharedPointer::make_mut(children.next().unwrap());
-                    // Prepare the rebalanced node.
-                    child.push_max(right.children[0].clone(), self.keys[index].clone());
-                    match child.remove_target(target) {
-                        Remove::NoChange => {
-                            // Key wasn't there, we need to revert the steal.
-                            child.pop_max();
-                            return Remove::NoChange;
-                        }
-                        Remove::Removed(value) => {
-                            // If we did remove something, we complete the rebalancing.
-                            let (right_value, _) = right.pop_min();
-                            self.keys[index] = right_value;
-                            out_value = value;
-                        }
-                        Remove::Update(value, new_child) => {
-                            // If we did remove something, we complete the rebalancing.
-                            let (right_value, _) = right.pop_min();
-                            self.keys[index] = right_value;
-                            update = Some(new_child);
-                            out_value = value;
-                        }
-                    }
-                }
-                if let Some(new_child) = update {
-                    self.children[index] = Some(SharedPointer::new(new_child));
-                }
-                Remove::Removed(out_value)
-            }
-            RemoveAction::MergeFirst(index) => {
-                if let Ok(key) = target {
-                    // Bail early if we're looking for a not existing key
-                    match self.keys[index].cmp_keys(key) {
-                        Ordering::Less if !self.child_contains(index + 1, key) => {
-                            return Remove::NoChange
-                        }
-                        Ordering::Greater if !self.child_contains(index, key) => {
-                            return Remove::NoChange
-                        }
-                        _ => (),
-                    }
-                }
-                let left = self.children.remove(index).unwrap();
-                let right = self.children[index].take().unwrap();
-                let middle = self.keys.remove(index);
-                let mut merged = Node::merge(middle, clone_ref(left), clone_ref(right));
-                let update;
-                let out_value;
-                match merged.remove_target(target) {
-                    Remove::NoChange => {
-                        panic!("nodes::btree::Node::remove: caught an absent key too late while merging");
-                    }
-                    Remove::Removed(value) => {
-                        if self.keys.is_empty() {
-                            return Remove::Update(value, merged);
-                        }
-                        update = merged;
-                        out_value = value;
-                    }
-                    Remove::Update(value, new_child) => {
-                        if self.keys.is_empty() {
-                            return Remove::Update(value, new_child);
-                        }
-                        update = new_child;
-                        out_value = value;
-                    }
-                }
-                self.children[index] = Some(SharedPointer::new(update));
-                Remove::Removed(out_value)
-            }
-            RemoveAction::ContinueDown(index) => {
-                let mut update = None;
-                let out_value;
-                if let Some(&mut Some(ref mut child_ref)) = self.children.get_mut(index) {
-                    let child = SharedPointer::make_mut(child_ref);
-                    match child.remove_target(target) {
-                        Remove::NoChange => return Remove::NoChange,
-                        Remove::Removed(value) => {
-                            out_value = value;
-                        }
-                        Remove::Update(value, new_child) => {
-                            update = Some(new_child);
-                            out_value = value;
-                        }
-                    }
-                } else {
-                    unreachable!()
-                }
-                if let Some(new_child) = update {
-                    self.children[index] = Some(SharedPointer::new(new_child));
-                }
-                Remove::Removed(out_value)
             }
         }
     }
 }
 
-// Iterator
-
-/// An iterator over an ordered set.
-pub(crate) struct Iter<'a, A, P: SharedPointerKind> {
-    /// Path to the next element that we'll yield if we take a forward step.  Each element here is
-    /// of the form `(node, index)`. For the last path element, `index` points to the next key to
-    /// yield. For every other path element, `index` is the child index of the next node in the
-    /// path.
-    fwd_path: Vec<(&'a Node<A, P>, usize)>,
-    /// Path to the next element that we'll yield if we take a backward step. This has the same
-    /// format as `fwd_path`.
-    back_path: Vec<(&'a Node<A, P>, usize)>,
-    pub(crate) remaining: usize,
-}
-
-// We impl Clone instead of deriving it, because we want Clone even if K and V aren't.
-impl<'a, A, P: SharedPointerKind> Clone for Iter<'a, A, P> {
+impl<K: Clone, V: Clone> Clone for Leaf<K, V> {
     fn clone(&self) -> Self {
-        Iter {
-            fwd_path: self.fwd_path.clone(),
-            back_path: self.back_path.clone(),
-            remaining: self.remaining,
+        Self {
+            keys: self.keys.clone(),
         }
     }
 }
 
-impl<'a, A: BTreeValue, P: SharedPointerKind> Iter<'a, A, P> {
-    pub(crate) fn new<R, BK>(root: &'a Node<A, P>, size: usize, range: R) -> Self
-    where
-        R: RangeBounds<BK>,
-        A::Key: Borrow<BK>,
-        BK: Ord + ?Sized,
-    {
-        let fwd_path = match range.start_bound() {
-            Bound::Included(key) => root.path_next(key, Vec::new()),
-            Bound::Excluded(key) => {
-                let mut path = root.path_next(key, Vec::new());
-                if let Some(value) = Self::get(&path) {
-                    if value.cmp_keys(key) == Ordering::Equal {
-                        Self::step_forward(&mut path);
-                    }
-                }
-                path
-            }
-            Bound::Unbounded => root.path_first(Vec::new()),
-        };
-        let back_path = match range.end_bound() {
-            Bound::Included(key) => root.path_prev(key, Vec::new()),
-            Bound::Excluded(key) => {
-                let mut path = root.path_prev(key, Vec::new());
-                if let Some(value) = Self::get(&path) {
-                    if value.cmp_keys(key) == Ordering::Equal {
-                        Self::step_back(&mut path);
-                    }
-                }
-                path
-            }
-            Bound::Unbounded => root.path_last(Vec::new()),
-        };
-        Iter {
-            fwd_path,
-            back_path,
-            remaining: size,
-        }
-    }
-
-    fn get(path: &[(&'a Node<A, P>, usize)]) -> Option<&'a A> {
-        match path.last() {
-            Some((node, index)) => Some(&node.keys[*index]),
-            None => None,
-        }
-    }
-
-    fn step_forward(path: &mut Vec<(&'a Node<A, P>, usize)>) -> Option<&'a A> {
-        match path.pop() {
-            Some((node, index)) => {
-                let index = index + 1;
-                match node.children[index] {
-                    // Child between current and next key -> step down
-                    Some(ref child) => {
-                        path.push((node, index));
-                        path.push((child, 0));
-                        let mut node = child;
-                        while let Some(ref left_child) = node.children[0] {
-                            path.push((left_child, 0));
-                            node = left_child;
-                        }
-                        Some(&node.keys[0])
-                    }
-                    None => match node.keys.get(index) {
-                        // Yield next key
-                        value @ Some(_) => {
-                            path.push((node, index));
-                            value
-                        }
-                        // No more keys -> exhausted level, step up and yield
-                        None => loop {
-                            match path.pop() {
-                                None => {
-                                    return None;
-                                }
-                                Some((node, index)) => {
-                                    if let value @ Some(_) = node.keys.get(index) {
-                                        path.push((node, index));
-                                        return value;
-                                    }
-                                }
-                            }
-                        },
-                    },
-                }
-            }
-            None => None,
-        }
-    }
-
-    fn step_back(path: &mut Vec<(&'a Node<A, P>, usize)>) -> Option<&'a A> {
-        // TODO: we're doing some repetitive leaf-vs-internal checking.
-        match path.pop() {
-            Some((node, index)) => match node.children[index] {
-                Some(ref child) => {
-                    path.push((node, index));
-                    let mut end = if child.is_leaf() {
-                        child.keys.len() - 1
-                    } else {
-                        child.children.len() - 1
-                    };
-                    path.push((child, end));
-                    let mut node = child;
-                    while let Some(ref right_child) = node.children[end] {
-                        end = if right_child.is_leaf() {
-                            right_child.keys.len() - 1
-                        } else {
-                            right_child.children.len() - 1
-                        };
-                        path.push((right_child, end));
-                        node = right_child;
-                    }
-                    Some(&node.keys[end])
-                }
-                None => {
-                    if index == 0 {
-                        loop {
-                            match path.pop() {
-                                None => {
-                                    return None;
-                                }
-                                Some((node, index)) => {
-                                    if index > 0 {
-                                        let index = index - 1;
-                                        path.push((node, index));
-                                        return Some(&node.keys[index]);
-                                    }
-                                }
-                            }
-                        }
-                    } else {
-                        let index = index - 1;
-                        path.push((node, index));
-                        Some(&node.keys[index])
-                    }
-                }
-            },
-            None => None,
+impl<K: Clone, V: Clone, P: SharedPointerKind> Clone for Branch<K, V, P> {
+    fn clone(&self) -> Self {
+        Self {
+            keys: self.keys.clone(),
+            children: self.children.clone(),
+            level: self.level,
         }
     }
 }
 
-impl<'a, A: 'a + BTreeValue, P: SharedPointerKind> Iterator for Iter<'a, A, P> {
-    type Item = &'a A;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match Iter::get(&self.fwd_path) {
-            None => None,
-            Some(value) => match Iter::get(&self.back_path) {
-                Some(last_value) if value.cmp_values(last_value) == Ordering::Greater => None,
-                None => None,
-                Some(_) => {
-                    Iter::step_forward(&mut self.fwd_path);
-                    self.remaining -= 1;
-                    Some(value)
-                }
-            },
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, Some(self.remaining))
-    }
-}
-
-impl<'a, A: 'a + BTreeValue, P: SharedPointerKind> DoubleEndedIterator for Iter<'a, A, P> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        match Iter::get(&self.back_path) {
-            None => None,
-            Some(value) => match Iter::get(&self.fwd_path) {
-                Some(last_value) if value.cmp_values(last_value) == Ordering::Less => None,
-                None => None,
-                Some(_) => {
-                    Iter::step_back(&mut self.back_path);
-                    self.remaining -= 1;
-                    Some(value)
-                }
-            },
+impl<K: Clone, V: Clone, P: SharedPointerKind> Clone for Node<K, V, P> {
+    fn clone(&self) -> Self {
+        match self {
+            Node::Branch(branch) => Node::Branch(branch.clone()),
+            Node::Leaf(leaf) => Node::Leaf(leaf.clone()),
         }
     }
 }
 
-// Consuming iterator
-
-enum ConsumingIterItem<A, P: SharedPointerKind> {
-    Consider(Node<A, P>),
-    Yield(A),
+pub(crate) enum InsertAction<K, V, P: SharedPointerKind> {
+    Inserted,
+    Replaced(K, V),
+    Split(K, SharedPointer<Node<K, V, P>, P>),
 }
 
-/// A consuming iterator over an ordered set.
-pub struct ConsumingIter<A, P: SharedPointerKind> {
-    fwd_last: Option<A>,
-    fwd_stack: Vec<ConsumingIterItem<A, P>>,
-    back_last: Option<A>,
-    back_stack: Vec<ConsumingIterItem<A, P>>,
+impl<K, V, P: SharedPointerKind> Default for Node<K, V, P> {
+    fn default() -> Self {
+        Node::Leaf(Leaf { keys: Chunk::new() })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ConsumingIter<K, V, P: SharedPointerKind> {
+    /// The leaves of the tree, in order, note that this will remain the shared ptr
+    /// as it will allows us to have a smaller VecDeque allocation and avoid eagerly
+    /// cloning the leaves, which defeats the purpose of this iterator.
+    /// Leaves present in the VecDeque are guaranteed to be non-empty.
+    leaves: VecDeque<SharedPointer<Node<K, V, P>, P>>,
     remaining: usize,
 }
 
-impl<A: Clone, P: SharedPointerKind> ConsumingIter<A, P> {
-    pub(crate) fn new(root: &Node<A, P>, total: usize) -> Self {
-        ConsumingIter {
-            fwd_last: None,
-            fwd_stack: vec![ConsumingIterItem::Consider(root.clone())],
-            back_last: None,
-            back_stack: vec![ConsumingIterItem::Consider(root.clone())],
-            remaining: total,
+impl<K, V, P: SharedPointerKind> ConsumingIter<K, V, P> {
+    pub(crate) fn new(node: Option<SharedPointer<Node<K, V, P>, P>>, size: usize) -> Self {
+        fn push<K, V, P: SharedPointerKind>(
+            leaves: &mut VecDeque<SharedPointer<Node<K, V, P>, P>>,
+            node: SharedPointer<Node<K, V, P>, P>,
+        ) {
+            match &*node {
+                Node::Branch(branch) => {
+                    if branch.level == 1 {
+                        leaves.extend(branch.children.iter().cloned());
+                    } else {
+                        for child in branch.children.iter() {
+                            push(leaves, child.clone());
+                        }
+                    }
+                }
+                Node::Leaf(leaf) if !leaf.keys.is_empty() => leaves.push_back(node),
+                Node::Leaf(_) => (),
+            }
         }
-    }
-
-    fn push_node(
-        stack: &mut Vec<ConsumingIterItem<A, P>>,
-        maybe_node: Option<SharedPointer<Node<A, P>, P>>,
-    ) {
-        if let Some(node) = maybe_node {
-            stack.push(ConsumingIterItem::Consider(clone_ref(node)))
+        // preallocate the VecDeque assuming each leaf is half full
+        let mut leaves = VecDeque::with_capacity(size.div_ceil(NODE_SIZE / 2));
+        if let Some(node) = node {
+            push(&mut leaves, node);
         }
-    }
-
-    fn push(stack: &mut Vec<ConsumingIterItem<A, P>>, mut node: Node<A, P>) {
-        for _n in 0..node.keys.len() {
-            ConsumingIter::push_node(stack, node.children.pop_back());
-            stack.push(ConsumingIterItem::Yield(node.keys.pop_back()));
+        Self {
+            leaves,
+            remaining: size,
         }
-        ConsumingIter::push_node(stack, node.children.pop_back());
-    }
-
-    fn push_fwd(&mut self, node: Node<A, P>) {
-        ConsumingIter::push(&mut self.fwd_stack, node)
-    }
-
-    fn push_node_back(&mut self, maybe_node: Option<SharedPointer<Node<A, P>, P>>) {
-        if let Some(node) = maybe_node {
-            self.back_stack
-                .push(ConsumingIterItem::Consider(clone_ref(node)))
-        }
-    }
-
-    fn push_back(&mut self, mut node: Node<A, P>) {
-        for _i in 0..node.keys.len() {
-            self.push_node_back(node.children.pop_front());
-            self.back_stack
-                .push(ConsumingIterItem::Yield(node.keys.pop_front()));
-        }
-        self.push_node_back(node.children.pop_back());
     }
 }
 
-impl<A, P> Iterator for ConsumingIter<A, P>
-where
-    A: BTreeValue + Clone,
-    P: SharedPointerKind,
-{
-    type Item = A;
+impl<K: Clone, V: Clone, P: SharedPointerKind> Iterator for ConsumingIter<K, V, P> {
+    type Item = (K, V);
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            match self.fwd_stack.pop() {
-                None => {
-                    self.remaining = 0;
-                    return None;
-                }
-                Some(ConsumingIterItem::Consider(node)) => self.push_fwd(node),
-                Some(ConsumingIterItem::Yield(value)) => {
-                    if let Some(ref last) = self.back_last {
-                        if value.cmp_values(last) != Ordering::Less {
-                            self.fwd_stack.clear();
-                            self.back_stack.clear();
-                            self.remaining = 0;
-                            return None;
-                        }
-                    }
-                    self.remaining -= 1;
-                    self.fwd_last = Some(value.clone());
-                    return Some(value);
-                }
-            }
+        let node = self.leaves.front_mut()?;
+        let Node::Leaf(leaf) = SharedPointer::make_mut(node) else {
+            unreachable!()
+        };
+        self.remaining -= 1;
+        let item = leaf.keys.pop_front();
+        if leaf.keys.is_empty() {
+            self.leaves.pop_front();
         }
+        Some(item)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -1270,166 +542,345 @@ where
     }
 }
 
-impl<A, P> DoubleEndedIterator for ConsumingIter<A, P>
-where
-    A: BTreeValue + Clone,
-    P: SharedPointerKind,
-{
+impl<K: Clone, V: Clone, P: SharedPointerKind> DoubleEndedIterator for ConsumingIter<K, V, P> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        loop {
-            match self.back_stack.pop() {
-                None => {
-                    self.remaining = 0;
-                    return None;
-                }
-                Some(ConsumingIterItem::Consider(node)) => self.push_back(node),
-                Some(ConsumingIterItem::Yield(value)) => {
-                    if let Some(ref last) = self.fwd_last {
-                        if value.cmp_values(last) != Ordering::Greater {
-                            self.fwd_stack.clear();
-                            self.back_stack.clear();
-                            self.remaining = 0;
-                            return None;
-                        }
-                    }
-                    self.remaining -= 1;
-                    self.back_last = Some(value.clone());
-                    return Some(value);
+        let node = self.leaves.back_mut()?;
+        let Node::Leaf(leaf) = SharedPointer::make_mut(node) else {
+            unreachable!()
+        };
+        self.remaining -= 1;
+        let item = leaf.keys.pop_back();
+        if leaf.keys.is_empty() {
+            self.leaves.pop_back();
+        }
+        Some(item)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Iter<'a, K, V, P: SharedPointerKind> {
+    /// The forward and backward cursors
+    /// The cursors are lazily initialized if their corresponding bound is unbounded
+    fwd: Cursor<'a, K, V, P>,
+    bwd: Cursor<'a, K, V, P>,
+    fwd_yielded: bool,
+    bwd_yielded: bool,
+    exhausted: bool,
+    exact: bool,
+    remaining: usize,
+    root: Option<&'a Node<K, V, P>>,
+}
+
+impl<'a, K, V, P: SharedPointerKind> Iter<'a, K, V, P> {
+    pub(crate) fn new<R, BK>(root: Option<&'a Node<K, V, P>>, len: usize, range: R) -> Self
+    where
+        R: RangeBounds<BK>,
+        K: Borrow<BK>,
+        BK: Ord + ?Sized,
+    {
+        let mut fwd = Cursor::empty();
+        let mut bwd = Cursor::empty();
+        let mut exhausted = match range.start_bound() {
+            Bound::Included(key) | Bound::Excluded(key) => {
+                fwd.init(root);
+                if fwd.seek_to_key(key, false) && matches!(range.start_bound(), Bound::Excluded(_))
+                {
+                    fwd.next().is_none()
+                } else {
+                    fwd.stack.is_empty()
                 }
             }
+            Bound::Unbounded => false,
+        };
+
+        exhausted = match (exhausted, range.end_bound()) {
+            (false, Bound::Included(key) | Bound::Excluded(key)) => {
+                bwd.init(root);
+                if bwd.seek_to_key(key, true) && matches!(range.end_bound(), Bound::Excluded(_)) {
+                    bwd.prev().is_none()
+                } else {
+                    bwd.stack.is_empty()
+                }
+            }
+            (exhausted, _) => exhausted,
+        };
+
+        // Check if forward is > backward cursor to determine if we are exhausted
+        // Due to the usage of zip this is correct even if the cursors are already or not initialized yet
+        for (&(fi, f), &(bi, b)) in fwd.stack.iter().zip(bwd.stack.iter()) {
+            if !std::ptr::addr_eq(f, b) {
+                break;
+            }
+            if fi > bi {
+                exhausted = true;
+                break;
+            }
+        }
+
+        let exact = matches!(range.start_bound(), Bound::Unbounded)
+            && matches!(range.end_bound(), Bound::Unbounded);
+
+        Self {
+            fwd,
+            bwd,
+            remaining: len,
+            exact,
+            exhausted,
+            fwd_yielded: false,
+            bwd_yielded: false,
+            root,
         }
     }
-}
 
-impl<A: BTreeValue + Clone, P: SharedPointerKind> ExactSizeIterator for ConsumingIter<A, P> {}
+    /// Updates the exhausted state of the iterator.
+    /// Returns true if the iterator is immaterially exhausted, which implies ignoring the
+    /// current next candidate, if any.
+    #[inline]
+    fn update_exhausted(&mut self, has_next: bool, other_side_yielded: bool) -> bool {
+        debug_assert!(!self.exhausted);
+        if !has_next {
+            self.exhausted = true;
+            return true;
+        }
+        // Check if the cursors are exhausted by checking their leaves
+        // This is valid even if the cursors are empty due to not being initialized yet.
+        // If they were empty because exhaustion we would not be in this function.
+        if let (Some(&(fi, f)), Some(&(bi, b))) = (self.fwd.stack.last(), self.bwd.stack.last()) {
+            if std::ptr::addr_eq(f, b) && fi >= bi {
+                self.exhausted = true;
+                return fi == bi && other_side_yielded;
+            }
+        }
+        false
+    }
 
-// DiffIter
-
-/// An iterator over the differences between two ordered sets.
-pub struct DiffIter<'a, 'b, A, P: SharedPointerKind> {
-    old_stack: Vec<IterItem<'a, A, P>>,
-    new_stack: Vec<IterItem<'b, A, P>>,
-}
-
-/// A description of a difference between two ordered sets.
-#[derive(PartialEq, Eq, Debug)]
-pub enum DiffItem<'a, 'b, A> {
-    /// This value has been added to the new set.
-    Add(&'b A),
-    /// This value has been changed between the two sets.
-    Update {
-        /// The old value.
-        old: &'a A,
-        /// The new value.
-        new: &'b A,
-    },
-    /// This value has been removed from the new set.
-    Remove(&'a A),
-}
-
-enum IterItem<'a, A, P: SharedPointerKind> {
-    Consider(&'a Node<A, P>),
-    Yield(&'a A),
-}
-
-impl<'a, 'b, A: 'a + 'b, P: SharedPointerKind> DiffIter<'a, 'b, A, P> {
-    pub(crate) fn new(old: &'a Node<A, P>, new: &'b Node<A, P>) -> Self {
-        DiffIter {
-            old_stack: if old.keys.is_empty() {
-                Vec::new()
+    #[cold]
+    fn peek_initial(&mut self, fwd: bool) -> Option<&'a (K, V)> {
+        debug_assert!(!self.exhausted);
+        let cursor = if fwd {
+            self.fwd_yielded = true;
+            &mut self.fwd
+        } else {
+            self.bwd_yielded = true;
+            &mut self.bwd
+        };
+        // If the cursor is empty we need to initialize it and seek to the first/last element.
+        // If they were empty because exhaustion we would not be in this function.
+        if cursor.stack.is_empty() {
+            cursor.init(self.root);
+            if fwd {
+                cursor.seek_to_first();
             } else {
-                vec![IterItem::Consider(old)]
-            },
-            new_stack: if new.keys.is_empty() {
-                Vec::new()
-            } else {
-                vec![IterItem::Consider(new)]
-            },
+                cursor.seek_to_last();
+            }
         }
-    }
-
-    fn push_node<'either>(
-        stack: &mut Vec<IterItem<'either, A, P>>,
-        maybe_node: &'either Option<SharedPointer<Node<A, P>, P>>,
-    ) {
-        if let Some(node) = maybe_node {
-            stack.push(IterItem::Consider(node))
-        }
-    }
-
-    fn push<'either>(stack: &mut Vec<IterItem<'either, A, P>>, node: &'either Node<A, P>) {
-        for n in 0..node.keys.len() {
-            let i = node.keys.len() - n;
-            Self::push_node(stack, &node.children[i]);
-            stack.push(IterItem::Yield(&node.keys[i - 1]));
-        }
-        Self::push_node(stack, &node.children[0]);
+        cursor.peek()
     }
 }
 
-impl<'a, 'b, A, P> Iterator for DiffIter<'a, 'b, A, P>
-where
-    A: 'a + 'b + BTreeValue + PartialEq,
-    P: SharedPointerKind,
-{
-    type Item = DiffItem<'a, 'b, A>;
+impl<'a, K, V, P: SharedPointerKind> Iterator for Iter<'a, K, V, P> {
+    type Item = (&'a K, &'a V);
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            match (self.old_stack.pop(), self.new_stack.pop()) {
-                (None, None) => return None,
-                (None, Some(new)) => match new {
-                    IterItem::Consider(new) => Self::push(&mut self.new_stack, new),
-                    IterItem::Yield(new) => return Some(DiffItem::Add(new)),
-                },
-                (Some(old), None) => match old {
-                    IterItem::Consider(old) => Self::push(&mut self.old_stack, old),
-                    IterItem::Yield(old) => return Some(DiffItem::Remove(old)),
-                },
-                (Some(old), Some(new)) => match (old, new) {
-                    (IterItem::Consider(old), IterItem::Consider(new)) => {
-                        if !std::ptr::eq(old, new) {
-                            match old.keys[0].cmp_values(&new.keys[0]) {
-                                Ordering::Less => {
-                                    Self::push(&mut self.old_stack, old);
-                                    self.new_stack.push(IterItem::Consider(new));
-                                }
-                                Ordering::Greater => {
-                                    self.old_stack.push(IterItem::Consider(old));
-                                    Self::push(&mut self.new_stack, new);
-                                }
-                                Ordering::Equal => {
-                                    Self::push(&mut self.old_stack, old);
-                                    Self::push(&mut self.new_stack, new);
-                                }
-                            }
-                        }
-                    }
-                    (IterItem::Consider(old), IterItem::Yield(new)) => {
-                        Self::push(&mut self.old_stack, old);
-                        self.new_stack.push(IterItem::Yield(new));
-                    }
-                    (IterItem::Yield(old), IterItem::Consider(new)) => {
-                        self.old_stack.push(IterItem::Yield(old));
-                        Self::push(&mut self.new_stack, new);
-                    }
-                    (IterItem::Yield(old), IterItem::Yield(new)) => match old.cmp_values(new) {
-                        Ordering::Less => {
-                            self.new_stack.push(IterItem::Yield(new));
-                            return Some(DiffItem::Remove(old));
-                        }
-                        Ordering::Equal => {
-                            if old != new {
-                                return Some(DiffItem::Update { old, new });
-                            }
-                        }
-                        Ordering::Greater => {
-                            self.old_stack.push(IterItem::Yield(old));
-                            return Some(DiffItem::Add(new));
-                        }
-                    },
-                },
+        if self.exhausted {
+            return None;
+        }
+        let next = if self.fwd_yielded {
+            self.fwd.next()
+        } else {
+            self.peek_initial(true)
+        }
+        .map(|(k, v)| (k, v));
+        if self.update_exhausted(next.is_some(), self.bwd_yielded) {
+            return None;
+        }
+        self.remaining -= 1;
+        next
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.exhausted {
+            return (0, Some(0));
+        }
+        let lb = if self.exact { self.remaining } else { 0 };
+        (lb, Some(self.remaining))
+    }
+}
+
+impl<'a, K, V, P: SharedPointerKind> DoubleEndedIterator for Iter<'a, K, V, P> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.exhausted {
+            return None;
+        }
+        let next = if self.bwd_yielded {
+            self.bwd.prev()
+        } else {
+            self.peek_initial(false)
+        }
+        .map(|(k, v)| (k, v));
+        if self.update_exhausted(next.is_some(), self.fwd_yielded) {
+            return None;
+        }
+        self.remaining -= 1;
+        next
+    }
+}
+
+impl<'a, K, V, P: SharedPointerKind> Clone for Iter<'a, K, V, P> {
+    fn clone(&self) -> Self {
+        Self {
+            fwd: self.fwd.clone(),
+            bwd: self.bwd.clone(),
+            exact: self.exact,
+            fwd_yielded: self.fwd_yielded,
+            bwd_yielded: self.bwd_yielded,
+            exhausted: self.exhausted,
+            remaining: self.remaining,
+            root: self.root,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Cursor<'a, K, V, P: SharedPointerKind> {
+    stack: Vec<(usize, &'a Node<K, V, P>)>,
+}
+
+impl<'a, K, V, P: SharedPointerKind> Clone for Cursor<'a, K, V, P> {
+    fn clone(&self) -> Self {
+        Self {
+            stack: self.stack.clone(),
+        }
+    }
+}
+
+impl<'a, K, V, P: SharedPointerKind> Cursor<'a, K, V, P> {
+    fn empty() -> Self {
+        Self { stack: Vec::new() }
+    }
+
+    fn init(&mut self, node: Option<&'a Node<K, V, P>>) {
+        if let Some(node) = node {
+            self.stack.reserve_exact(node.level() + 1);
+            self.stack.push((0, node));
+        }
+    }
+
+    fn seek_to_first(&mut self) -> Option<&'a (K, V)> {
+        while let Some((i, node)) = self.stack.last_mut() {
+            debug_assert_eq!(i, &0);
+            match node {
+                Node::Branch(branch) => {
+                    self.stack.push((0, &branch.children[0]));
+                }
+                Node::Leaf(leaf) => return leaf.keys.first(),
             }
+        }
+        None
+    }
+
+    fn seek_to_last(&mut self) -> Option<&'a (K, V)> {
+        while let Some((i, node)) = self.stack.last_mut() {
+            debug_assert_eq!(i, &0);
+            match node {
+                Node::Branch(branch) => {
+                    *i = branch.children.len() - 1;
+                    let child = &branch.children[*i];
+                    self.stack.push((0, child));
+                }
+                Node::Leaf(leaf) => {
+                    *i = leaf.keys.len().saturating_sub(1);
+                    return leaf.keys.last();
+                }
+            }
+        }
+        None
+    }
+
+    fn seek_to_key<BK>(&mut self, key: &BK, for_prev: bool) -> bool
+    where
+        BK: Ord + ?Sized,
+        K: Borrow<BK>,
+    {
+        while let Some((i, node)) = self.stack.last_mut() {
+            match node {
+                Node::Branch(branch) => {
+                    *i = branch
+                        .keys
+                        .binary_search_by(|k| k.borrow().cmp(key))
+                        .map(|x| x + 1)
+                        .unwrap_or_else(|x| x);
+                    let child = &branch.children[*i];
+                    self.stack.push((0, child));
+                }
+                Node::Leaf(leaf) => {
+                    let search = leaf.keys.binary_search_by(|(k, _)| k.borrow().cmp(key));
+                    *i = search.unwrap_or_else(|x| x);
+                    if for_prev {
+                        if search.is_err() {
+                            self.prev();
+                        }
+                    } else if search == Err(leaf.keys.len()) {
+                        self.next();
+                    }
+                    return search.is_ok();
+                }
+            }
+        }
+        false
+    }
+
+    fn next(&mut self) -> Option<&'a (K, V)> {
+        while let Some((i, node)) = self.stack.last_mut() {
+            match node {
+                Node::Branch(branch) => {
+                    if *i + 1 < branch.children.len() {
+                        *i += 1;
+                        let child = &branch.children[*i];
+                        self.stack.push((0, child));
+                        break;
+                    }
+                }
+                Node::Leaf(leaf) => {
+                    if *i + 1 < leaf.keys.len() {
+                        *i += 1;
+                        return leaf.keys.get(*i);
+                    }
+                }
+            }
+            self.stack.pop();
+        }
+        self.seek_to_first()
+    }
+
+    fn prev(&mut self) -> Option<&'a (K, V)> {
+        while let Some((i, node)) = self.stack.last_mut() {
+            match node {
+                Node::Branch(branch) => {
+                    if *i > 0 {
+                        *i -= 1;
+                        let child = &branch.children[*i];
+                        self.stack.push((0, child));
+                        break;
+                    }
+                }
+                Node::Leaf(leaf) => {
+                    if *i > 0 {
+                        *i -= 1;
+                        return leaf.keys.get(*i);
+                    }
+                }
+            }
+            self.stack.pop();
+        }
+        self.seek_to_last()
+    }
+
+    fn peek(&self) -> Option<&'a (K, V)> {
+        if let Some((i, Node::Leaf(leaf))) = self.stack.last() {
+            leaf.keys.get(*i)
+        } else {
+            None
         }
     }
 }

--- a/src/ord/map.rs
+++ b/src/ord/map.rs
@@ -528,6 +528,22 @@ where
     {
         self.is_proper_submap_by(other.borrow(), PartialEq::eq)
     }
+
+    /// Check invariants
+    #[cfg(any(test, fuzzing))]
+    #[allow(unreachable_pub)]
+    pub fn check_sane(&self)
+    where
+        K: std::fmt::Debug,
+        V: std::fmt::Debug,
+    {
+        let size = self
+            .root
+            .as_ref()
+            .map(|root| root.check_sane(true))
+            .unwrap_or(0);
+        assert_eq!(size, self.size);
+    }
 }
 
 impl<K, V, P> GenericOrdMap<K, V, P>

--- a/src/ord/set.rs
+++ b/src/ord/set.rs
@@ -4,7 +4,7 @@
 
 //! An ordered set.
 //!
-//! An immutable ordered set implemented as a [B-tree] [1].
+//! An immutable ordered set implemented as a [B+tree] [1].
 //!
 //! Most operations on this type of set are O(log n). A
 //! [`GenericHashSet`] is usually a better choice for
@@ -13,26 +13,22 @@
 //! ordered, so values always come out from lowest to highest, where a
 //! [`GenericHashSet`] has no guaranteed ordering.
 //!
-//! [1]: https://en.wikipedia.org/wiki/B-tree
+//! [1]: https://en.wikipedia.org/wiki/B%2B_tree
 
 use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::collections;
 use std::fmt::{Debug, Error, Formatter};
 use std::hash::{BuildHasher, Hash, Hasher};
-use std::iter::{FromIterator, Sum};
-use std::ops::{Add, Deref, Mul, RangeBounds};
+use std::iter::{FromIterator, FusedIterator, Sum};
+use std::ops::{Add, Mul, RangeBounds};
 
-use archery::{SharedPointer, SharedPointerKind};
+use archery::SharedPointerKind;
 
+use super::map;
 use crate::hashset::GenericHashSet;
-use crate::nodes::btree::{
-    BTreeValue, ConsumingIter as ConsumingNodeIter, DiffIter as NodeDiffIter, Insert,
-    Iter as NodeIter, Node, Remove,
-};
 use crate::shared_ptr::DefaultSharedPtr;
-
-pub use crate::nodes::btree::DiffItem;
+use crate::GenericOrdMap;
 
 /// Construct a set from a sequence of values.
 ///
@@ -61,50 +57,6 @@ macro_rules! ordset {
     }};
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
-struct Value<A>(A);
-
-impl<A> Deref for Value<A> {
-    type Target = A;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-// FIXME lacking specialisation, we can't simply implement `BTreeValue`
-// for `A`, we have to use the `Value<A>` indirection.
-impl<A: Ord> BTreeValue for Value<A> {
-    type Key = A;
-
-    fn ptr_eq(&self, _other: &Self) -> bool {
-        false
-    }
-
-    fn search_key<BK>(slice: &[Self], key: &BK) -> Result<usize, usize>
-    where
-        BK: Ord + ?Sized,
-        Self::Key: Borrow<BK>,
-    {
-        slice.binary_search_by(|value| Self::Key::borrow(value).cmp(key))
-    }
-
-    fn search_value(slice: &[Self], key: &Self) -> Result<usize, usize> {
-        slice.binary_search_by(|value| value.cmp(key))
-    }
-
-    fn cmp_keys<BK>(&self, other: &BK) -> Ordering
-    where
-        BK: Ord + ?Sized,
-        Self::Key: Borrow<BK>,
-    {
-        Self::Key::borrow(self).cmp(other)
-    }
-
-    fn cmp_values(&self, other: &Self) -> Ordering {
-        self.cmp(other)
-    }
-}
-
 /// Type alias for [`GenericOrdSet`] that uses [`DefaultSharedPtr`] as the pointer type.
 ///
 /// [GenericOrdSet]: ./struct.GenericOrdSet.html
@@ -113,7 +65,7 @@ pub type OrdSet<A> = GenericOrdSet<A, DefaultSharedPtr>;
 
 /// An ordered set.
 ///
-/// An immutable ordered set implemented as a [B-tree] [1].
+/// An immutable ordered map implemented as a B+tree [1].
 ///
 /// Most operations on this type of set are O(log n). A
 /// [`GenericHashSet`] is usually a better choice for
@@ -122,10 +74,9 @@ pub type OrdSet<A> = GenericOrdSet<A, DefaultSharedPtr>;
 /// ordered, so values always come out from lowest to highest, where a
 /// [`GenericHashSet`] has no guaranteed ordering.
 ///
-/// [1]: https://en.wikipedia.org/wiki/B-tree
+/// [1]: https://en.wikipedia.org/wiki/B%2B_tree
 pub struct GenericOrdSet<A, P: SharedPointerKind> {
-    size: usize,
-    root: SharedPointer<Node<Value<A>, P>, P>,
+    map: GenericOrdMap<A, (), P>,
 }
 
 impl<A, P: SharedPointerKind> GenericOrdSet<A, P> {
@@ -133,8 +84,9 @@ impl<A, P: SharedPointerKind> GenericOrdSet<A, P> {
     #[inline]
     #[must_use]
     pub fn new() -> Self {
-        let root = SharedPointer::default();
-        GenericOrdSet { size: 0, root }
+        GenericOrdSet {
+            map: GenericOrdMap::new(),
+        }
     }
 
     /// Construct a set with a single value.
@@ -150,8 +102,9 @@ impl<A, P: SharedPointerKind> GenericOrdSet<A, P> {
     #[inline]
     #[must_use]
     pub fn unit(a: A) -> Self {
-        let root = SharedPointer::new(Node::unit(Value(a)));
-        GenericOrdSet { size: 1, root }
+        GenericOrdSet {
+            map: GenericOrdMap::unit(a, ()),
+        }
     }
 
     /// Test whether a set is empty.
@@ -190,7 +143,7 @@ impl<A, P: SharedPointerKind> GenericOrdSet<A, P> {
     #[inline]
     #[must_use]
     pub fn len(&self) -> usize {
-        self.size
+        self.map.len()
     }
 
     /// Test whether two sets refer to the same content in memory.
@@ -203,7 +156,7 @@ impl<A, P: SharedPointerKind> GenericOrdSet<A, P> {
     ///
     /// Time: O(1)
     pub fn ptr_eq(&self, other: &Self) -> bool {
-        std::ptr::eq(self, other) || SharedPointer::ptr_eq(&self.root, &other.root)
+        self.map.ptr_eq(&other.map)
     }
 
     /// Discard all elements from the set.
@@ -223,10 +176,7 @@ impl<A, P: SharedPointerKind> GenericOrdSet<A, P> {
     /// assert!(set.is_empty());
     /// ```
     pub fn clear(&mut self) {
-        if !self.is_empty() {
-            self.root = SharedPointer::default();
-            self.size = 0;
-        }
+        self.map.clear();
     }
 }
 
@@ -242,7 +192,7 @@ where
     /// Time: O(log n)
     #[must_use]
     pub fn get_min(&self) -> Option<&A> {
-        self.root.min().map(Deref::deref)
+        self.map.get_min().map(|v| &v.0)
     }
 
     /// Get the largest value in a set.
@@ -252,14 +202,14 @@ where
     /// Time: O(log n)
     #[must_use]
     pub fn get_max(&self) -> Option<&A> {
-        self.root.max().map(Deref::deref)
+        self.map.get_max().map(|v| &v.0)
     }
 
     /// Create an iterator over the contents of the set.
     #[must_use]
     pub fn iter(&self) -> Iter<'_, A, P> {
         Iter {
-            it: NodeIter::new(&self.root, self.size, ..),
+            it: self.map.iter(),
         }
     }
 
@@ -272,7 +222,7 @@ where
         BA: Ord + ?Sized,
     {
         RangedIter {
-            it: NodeIter::new(&self.root, self.size, range),
+            it: self.map.range(range),
         }
     }
 
@@ -290,7 +240,7 @@ where
     #[must_use]
     pub fn diff<'a, 'b>(&'a self, other: &'b Self) -> DiffIter<'a, 'b, A, P> {
         DiffIter {
-            it: NodeDiffIter::new(&self.root, &other.root),
+            it: self.map.diff(&other.map),
         }
     }
 
@@ -314,7 +264,7 @@ where
         BA: Ord + ?Sized,
         A: Borrow<BA>,
     {
-        self.root.lookup(a).is_some()
+        self.map.contains_key(a)
     }
 
     /// Returns a reference to the element in the set, if any, that is equal to the value.
@@ -355,7 +305,7 @@ where
         BK: Ord + ?Sized,
         A: Borrow<BK>,
     {
-        self.root.lookup(k).map(|v| &v.0)
+        self.map.get_key_value(k).map(|(k, _)| k)
     }
 
     /// Get the closest smaller value in a set to a given value.
@@ -379,7 +329,7 @@ where
         BK: Ord + ?Sized,
         A: Borrow<BK>,
     {
-        self.root.lookup_prev(k).map(|v| &v.0)
+        self.map.get_prev(k).map(|(k, _)| k)
     }
 
     /// Get the closest larger value in a set to a given value.
@@ -403,7 +353,7 @@ where
         BK: Ord + ?Sized,
         A: Borrow<BK>,
     {
-        self.root.lookup_next(k).map(|v| &v.0)
+        self.map.get_next(k).map(|(k, _)| k)
     }
 
     /// Test whether a set is a subset of another set, meaning that
@@ -460,22 +410,7 @@ where
     /// ```
     #[inline]
     pub fn insert(&mut self, a: A) -> Option<A> {
-        let new_root = {
-            let root = SharedPointer::make_mut(&mut self.root);
-            match root.insert(Value(a)) {
-                Insert::Replaced(Value(old_value)) => return Some(old_value),
-                Insert::Added => {
-                    self.size += 1;
-                    return None;
-                }
-                Insert::Split(left, median, right) => {
-                    SharedPointer::new(Node::new_from_split(left, median, right))
-                }
-            }
-        };
-        self.size += 1;
-        self.root = new_root;
-        None
+        self.map.insert_key_value(a, ()).map(|(k, _)| k)
     }
 
     /// Remove a value from a set.
@@ -487,20 +422,7 @@ where
         BA: Ord + ?Sized,
         A: Borrow<BA>,
     {
-        let (new_root, removed_value) = {
-            let root = SharedPointer::make_mut(&mut self.root);
-            match root.remove(a) {
-                Remove::Update(value, root) => (SharedPointer::new(root), Some(value.0)),
-                Remove::Removed(value) => {
-                    self.size -= 1;
-                    return Some(value.0);
-                }
-                Remove::NoChange => return None,
-            }
-        };
-        self.size -= 1;
-        self.root = new_root;
-        removed_value
+        self.map.remove_with_key(a).map(|(k, _)| k)
     }
 
     /// Remove the smallest value from a set.
@@ -508,11 +430,7 @@ where
     /// Time: O(log n)
     pub fn remove_min(&mut self) -> Option<A> {
         // FIXME implement this at the node level for better efficiency
-        let key = match self.get_min() {
-            None => return None,
-            Some(v) => v,
-        }
-        .clone();
+        let key = self.get_min()?.clone();
         self.remove(&key)
     }
 
@@ -521,11 +439,7 @@ where
     /// Time: O(log n)
     pub fn remove_max(&mut self) -> Option<A> {
         // FIXME implement this at the node level for better efficiency
-        let key = match self.get_max() {
-            None => return None,
-            Some(v) => v,
-        }
-        .clone();
+        let key = self.get_max()?.clone();
         self.remove(&key)
     }
 
@@ -765,7 +679,7 @@ where
         let mut right = Self::default();
         let mut present = false;
         for value in self {
-            match value.borrow().cmp(&split) {
+            match value.borrow().cmp(split) {
                 Ordering::Less => {
                     left.insert(value);
                 }
@@ -808,8 +722,7 @@ impl<A, P: SharedPointerKind> Clone for GenericOrdSet<A, P> {
     #[inline]
     fn clone(&self) -> Self {
         GenericOrdSet {
-            size: self.size,
-            root: self.root.clone(),
+            map: self.map.clone(),
         }
     }
 }
@@ -817,8 +730,7 @@ impl<A, P: SharedPointerKind> Clone for GenericOrdSet<A, P> {
 // TODO: Support PartialEq for OrdSet that have different P
 impl<A: Ord, P: SharedPointerKind> PartialEq for GenericOrdSet<A, P> {
     fn eq(&self, other: &Self) -> bool {
-        SharedPointer::ptr_eq(&self.root, &other.root)
-            || (self.len() == other.len() && self.diff(other).next().is_none())
+        self.map.eq(&other.map)
     }
 }
 
@@ -861,7 +773,7 @@ impl<A: Ord + Clone, P: SharedPointerKind> Add for GenericOrdSet<A, P> {
     }
 }
 
-impl<'a, A: Ord + Clone, P: SharedPointerKind> Add for &'a GenericOrdSet<A, P> {
+impl<A: Ord + Clone, P: SharedPointerKind> Add for &GenericOrdSet<A, P> {
     type Output = GenericOrdSet<A, P>;
 
     fn add(self, other: Self) -> Self::Output {
@@ -877,7 +789,7 @@ impl<A: Ord + Clone, P: SharedPointerKind> Mul for GenericOrdSet<A, P> {
     }
 }
 
-impl<'a, A: Ord + Clone, P: SharedPointerKind> Mul for &'a GenericOrdSet<A, P> {
+impl<A: Ord + Clone, P: SharedPointerKind> Mul for &GenericOrdSet<A, P> {
     type Output = GenericOrdSet<A, P>;
 
     fn mul(self, other: Self) -> Self::Output {
@@ -919,7 +831,7 @@ impl<A: Ord + Debug, P: SharedPointerKind> Debug for GenericOrdSet<A, P> {
 
 /// An iterator over the elements of a set.
 pub struct Iter<'a, A, P: SharedPointerKind> {
-    it: NodeIter<'a, Value<A>, P>,
+    it: map::Iter<'a, A, (), P>,
 }
 
 // We impl Clone instead of deriving it, because we want Clone even if K and V aren't.
@@ -941,11 +853,11 @@ where
     ///
     /// Time: O(1)*
     fn next(&mut self) -> Option<Self::Item> {
-        self.it.next().map(Deref::deref)
+        self.it.next().map(|(k, _)| k)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.it.remaining, Some(self.it.remaining))
+        self.it.size_hint()
     }
 }
 
@@ -955,11 +867,18 @@ where
     P: SharedPointerKind,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.it.next_back().map(Deref::deref)
+        self.it.next_back().map(|(k, _)| k)
     }
 }
 
 impl<'a, A, P> ExactSizeIterator for Iter<'a, A, P>
+where
+    A: 'a + Ord,
+    P: SharedPointerKind,
+{
+}
+
+impl<'a, A, P> FusedIterator for Iter<'a, A, P>
 where
     A: 'a + Ord,
     P: SharedPointerKind,
@@ -972,7 +891,7 @@ where
 /// `ExactSizeIterator` because we can't know the size of the range without first
 /// iterating over it to count.
 pub struct RangedIter<'a, A, P: SharedPointerKind> {
-    it: NodeIter<'a, Value<A>, P>,
+    it: map::RangedIter<'a, A, (), P>,
 }
 
 impl<'a, A, P> Iterator for RangedIter<'a, A, P>
@@ -986,7 +905,7 @@ where
     ///
     /// Time: O(1)*
     fn next(&mut self) -> Option<Self::Item> {
-        self.it.next().map(Deref::deref)
+        self.it.next().map(|(k, _)| k)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -1000,18 +919,18 @@ where
     P: SharedPointerKind,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.it.next_back().map(Deref::deref)
+        self.it.next_back().map(|(k, _)| k)
     }
 }
 
 /// A consuming iterator over the elements of a set.
 pub struct ConsumingIter<A, P: SharedPointerKind> {
-    it: ConsumingNodeIter<Value<A>, P>,
+    it: map::ConsumingIter<A, (), P>,
 }
 
 impl<A, P> Iterator for ConsumingIter<A, P>
 where
-    A: Ord + Clone,
+    A: Clone,
     P: SharedPointerKind,
 {
     type Item = A;
@@ -1024,9 +943,49 @@ where
     }
 }
 
+impl<A, P> DoubleEndedIterator for ConsumingIter<A, P>
+where
+    A: Clone,
+    P: SharedPointerKind,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.it.next_back().map(|v| v.0)
+    }
+}
+
+impl<A, P> ExactSizeIterator for ConsumingIter<A, P>
+where
+    A: Clone,
+    P: SharedPointerKind,
+{
+}
+
+impl<A, P> FusedIterator for ConsumingIter<A, P>
+where
+    A: Clone,
+    P: SharedPointerKind,
+{
+}
+
 /// An iterator over the difference between two sets.
 pub struct DiffIter<'a, 'b, A, P: SharedPointerKind> {
-    it: NodeDiffIter<'a, 'b, Value<A>, P>,
+    it: map::DiffIter<'a, 'b, A, (), P>,
+}
+
+/// A description of a difference between two ordered maps.
+#[derive(PartialEq, Eq, Debug)]
+pub enum DiffItem<'a, 'b, A> {
+    /// This value has been added to the new map.
+    Add(&'b A),
+    /// This value has been changed between the two maps.
+    Update {
+        /// The old value.
+        old: &'a A,
+        /// The new value.
+        new: &'b A,
+    },
+    /// This value has been removed from the new map.
+    Remove(&'a A),
 }
 
 impl<'a, 'b, A, P> Iterator for DiffIter<'a, 'b, A, P>
@@ -1041,12 +1000,12 @@ where
     /// Time: O(1)*
     fn next(&mut self) -> Option<Self::Item> {
         self.it.next().map(|item| match item {
-            DiffItem::Add(v) => DiffItem::Add(v.deref()),
-            DiffItem::Update { old, new } => DiffItem::Update {
-                old: old.deref(),
-                new: new.deref(),
+            map::DiffItem::Add(k, _) => DiffItem::Add(k),
+            map::DiffItem::Update { old, new } => DiffItem::Update {
+                old: old.0,
+                new: new.0,
             },
-            DiffItem::Remove(v) => DiffItem::Remove(v.deref()),
+            map::DiffItem::Remove(k, _) => DiffItem::Remove(k),
         })
     }
 }
@@ -1091,14 +1050,14 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         ConsumingIter {
-            it: ConsumingNodeIter::new(&self.root, self.size),
+            it: self.map.into_iter(),
         }
     }
 }
 
 // Conversions
 
-impl<'s, 'a, A, OA, P1, P2> From<&'s GenericOrdSet<&'a A, P2>> for GenericOrdSet<OA, P1>
+impl<A, OA, P1, P2> From<&GenericOrdSet<&A, P2>> for GenericOrdSet<OA, P1>
 where
     A: ToOwned<Owned = OA> + Ord + ?Sized,
     OA: Borrow<A> + Ord + Clone,
@@ -1126,7 +1085,7 @@ impl<A: Ord + Clone, P: SharedPointerKind> From<Vec<A>> for GenericOrdSet<A, P> 
     }
 }
 
-impl<'a, A: Ord + Clone, P: SharedPointerKind> From<&'a Vec<A>> for GenericOrdSet<A, P> {
+impl<A: Ord + Clone, P: SharedPointerKind> From<&Vec<A>> for GenericOrdSet<A, P> {
     fn from(vec: &Vec<A>) -> Self {
         vec.iter().cloned().collect()
     }
@@ -1140,7 +1099,7 @@ impl<A: Eq + Hash + Ord + Clone, P: SharedPointerKind> From<collections::HashSet
     }
 }
 
-impl<'a, A: Eq + Hash + Ord + Clone, P: SharedPointerKind> From<&'a collections::HashSet<A>>
+impl<A: Eq + Hash + Ord + Clone, P: SharedPointerKind> From<&collections::HashSet<A>>
     for GenericOrdSet<A, P>
 {
     fn from(hash_set: &collections::HashSet<A>) -> Self {
@@ -1154,9 +1113,7 @@ impl<A: Ord + Clone, P: SharedPointerKind> From<collections::BTreeSet<A>> for Ge
     }
 }
 
-impl<'a, A: Ord + Clone, P: SharedPointerKind> From<&'a collections::BTreeSet<A>>
-    for GenericOrdSet<A, P>
-{
+impl<A: Ord + Clone, P: SharedPointerKind> From<&collections::BTreeSet<A>> for GenericOrdSet<A, P> {
     fn from(btree_set: &collections::BTreeSet<A>) -> Self {
         btree_set.iter().cloned().collect()
     }
@@ -1170,13 +1127,8 @@ impl<A: Hash + Eq + Ord + Clone, S: BuildHasher, P1: SharedPointerKind, P2: Shar
     }
 }
 
-impl<
-        'a,
-        A: Hash + Eq + Ord + Clone,
-        S: BuildHasher,
-        P1: SharedPointerKind,
-        P2: SharedPointerKind,
-    > From<&'a GenericHashSet<A, S, P2>> for GenericOrdSet<A, P1>
+impl<A: Hash + Eq + Ord + Clone, S: BuildHasher, P1: SharedPointerKind, P2: SharedPointerKind>
+    From<&GenericHashSet<A, S, P2>> for GenericOrdSet<A, P1>
 {
     fn from(hashset: &GenericHashSet<A, S, P2>) -> Self {
         hashset.into_iter().cloned().collect()
@@ -1244,7 +1196,6 @@ mod test {
         fn proptest_a_set(ref s in ord_set(".*", 10..100)) {
             assert!(s.len() < 100);
             assert!(s.len() >= 10);
-            s.root.check_sane();
         }
 
         #[test]
@@ -1252,13 +1203,11 @@ mod test {
             let range = 0..max;
             let expected: Vec<i32> = range.clone().collect();
             let set: OrdSet<i32> = OrdSet::from_iter(range.clone());
-            set.root.check_sane();
             let result: Vec<i32> = set.range(..).cloned().collect();
             assert_eq!(expected, result);
 
             let expected: Vec<i32> = range.clone().rev().collect();
             let set: OrdSet<i32> = OrdSet::from_iter(range);
-            set.root.check_sane();
             let result: Vec<i32> = set.range(..).rev().cloned().collect();
             assert_eq!(expected, result);
         }

--- a/src/ord/set.rs
+++ b/src/ord/set.rs
@@ -384,6 +384,16 @@ where
     {
         self.len() != other.borrow().len() && self.is_subset(other)
     }
+
+    /// Check invariants
+    #[cfg(any(test, fuzzing))]
+    #[allow(unreachable_pub)]
+    pub fn check_sane(&self)
+    where
+        A: std::fmt::Debug,
+    {
+        self.map.check_sane();
+    }
 }
 
 impl<A, P> GenericOrdSet<A, P>
@@ -1134,22 +1144,11 @@ impl<A: Hash + Eq + Ord + Clone, S: BuildHasher, P1: SharedPointerKind, P2: Shar
     }
 }
 
-// Proptest
-#[cfg(any(test, feature = "proptest"))]
-#[doc(hidden)]
-pub mod proptest {
-    #[deprecated(
-        since = "14.3.0",
-        note = "proptest strategies have moved to imbl::proptest"
-    )]
-    pub use crate::proptest::ord_set;
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::proptest::*;
-    use ::proptest::proptest;
+    use proptest::proptest;
     use static_assertions::{assert_impl_all, assert_not_impl_any};
 
     assert_impl_all!(OrdSet<i32>: Send, Sync);

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -256,8 +256,8 @@ mod test {
         proptest::{hash_map, hash_set, ord_map, ord_set, vector},
         HashMap, HashSet, OrdMap, OrdSet, Vector,
     };
-    use ::proptest::num::i32;
-    use ::proptest::proptest;
+    use proptest::num::i32;
+    use proptest::proptest;
     use serde_json::{from_str, to_string};
 
     proptest! {


### PR DESCRIPTION
Rewrite OrdMap as a B+Tree for better performance and readability, as the BTree has more intricate semantics that get in the way of optimal performance. All the existing tests and APIs are kept, so it's theoretically a non-breaking change.

Performance is significantly better in most cases, with only a few small regressions. Such regressions are likely only visible in benchmarks, as the data structure is fully in the processor caches. In fact, real-world (cold cache) performance will likely be better with the new implementation as the branch keys are more tightly packed in memory. Thus, fewer cache misses are required to hit the leaves where most items are held due to the large branch factor.

A theoretical drawback of the new implementation is that there are some extra Key instances in the branches of the B+Tree (duplication ratio is approx 1/64, so small). In practice, this is negated by better representation for leaf nodes without children pointers. Since leaves correspond to roughly 63 out of every 64 nodes, there is more savings than waste.

```
name                       control.txt ns/iter  variable.txt ns/iter  diff ns/iter   diff %  speedup 
 ordmap_insert_100          24,788               21,295                      -3,493  -14.09%   x 1.16 
 ordmap_insert_1000         578,942              505,729                    -73,213  -12.65%   x 1.14 
 ordmap_insert_mut_100      3,876                2,987                         -889  -22.94%   x 1.30 
 ordmap_insert_mut_1000     64,962               44,032                     -20,930  -32.22%   x 1.48 
 ordmap_insert_mut_10000    830,714              640,438                   -190,276  -22.91%   x 1.30 
 ordmap_insert_mut_100000   10,663,181           8,326,248               -2,336,933  -21.92%   x 1.28 
 ordmap_insert_once_100     359                  323                            -36  -10.03%   x 1.11 
 ordmap_insert_once_1000    800                  770                            -30   -3.75%   x 1.04 
 ordmap_insert_once_10000   1,194                1,297                          103    8.63%   x 0.92 
 ordmap_iter_100            670                  487                           -183  -27.31%   x 1.38 
 ordmap_iter_1000           6,191                4,709                       -1,482  -23.94%   x 1.31 
 ordmap_iter_10000          61,713               46,936                     -14,777  -23.94%   x 1.31 
 ordmap_lookup_100          1,208                1,330                          122   10.10%   x 0.91 
 ordmap_lookup_1000         19,566               19,449                        -117   -0.60%   x 1.01 
 ordmap_lookup_10000        372,646              363,824                     -8,822   -2.37%   x 1.02 
 ordmap_lookup_100000       7,383,433            6,800,650                 -582,783   -7.89%   x 1.09 
 ordmap_lookup_once_100     12                   13                               1    8.33%   x 0.92 
 ordmap_lookup_once_1000    19                   18                              -1   -5.26%   x 1.06 
 ordmap_lookup_once_10000   31                   29                              -2   -6.45%   x 1.07 
 ordmap_lookup_once_100000  44                   41                              -3   -6.82%   x 1.07 
 ordmap_range_iter_100      670                  491                           -179  -26.72%   x 1.36 
 ordmap_range_iter_1000     6,177                4,686                       -1,491  -24.14%   x 1.32 
 ordmap_range_iter_10000    61,412               46,982                     -14,430  -23.50%   x 1.31 
 ordmap_range_iter_100000   620,106              470,040                   -150,066  -24.20%   x 1.32 
 ordmap_remove_100          28,340               21,686                      -6,654  -23.48%   x 1.31 
 ordmap_remove_1000         608,272              512,647                    -95,625  -15.72%   x 1.19 
 ordmap_remove_10000        12,563,534           10,778,287              -1,785,247  -14.21%   x 1.17 
 ordmap_remove_max_1000     590,836              535,068                    -55,768   -9.44%   x 1.10 
 ordmap_remove_min_1000     568,649              505,413                    -63,236  -11.12%   x 1.13 
 ordmap_remove_mut_100      4,698                3,331                       -1,367  -29.10%   x 1.41 
 ordmap_remove_mut_1000     69,832               44,150                     -25,682  -36.78%   x 1.58 
 ordmap_remove_mut_10000    1,396,004            1,047,703                 -348,301  -24.95%   x 1.33 
 ordmap_remove_once_100     356                  305                            -51  -14.33%   x 1.17 
 ordmap_remove_once_1000    798                  760                            -38   -4.76%   x 1.05 
 ordmap_remove_once_10000   1,098                1,033                          -65   -5.92%   x 1.06 
 ordmap_remove_once_100000  1,649                1,574                          -75   -4.55%   x 1.05
```

Other changes
* Modify OrdMap/Set new/default to not allocate an empty leaf node
* Removes benchmarks of magnitude 10 as they're not particularly meaningful and have a significant variance.
* Add benchmarks with larger magnitudes.
* Some non-standard APIs like `get_prev{,mut}()` and `diff()` have a theoretically slower implementation. There are no benchmarks for these so I haven't measured tbh. These are arguably less important and could be improved at a later time IMO
* Make fuzz tests longer and more aggressive wrt. input length
* Added myself as an author, given this and previous contributions. Hopefully that's ok with the maintainers.

I moved away from `im` a few years back after finding/fixing OrdMap bugs that never got merged. I think @jneem included them in `imbl` in the early days. I had some new interest in the crate recently, so I took a stab at this improvement before switching back to it.