### PR TITLE
Don't require `A: Ord` for `Vector::insert_ord_by()`.

### DIFF
--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1489,7 +1489,6 @@ impl<A: Clone, P: SharedPointerKind> GenericVector<A, P> {
     /// ```
     pub fn insert_ord_by<F>(&mut self, item: A, mut f: F)
     where
-        A: Ord,
         F: FnMut(&A, &A) -> Ordering,
     {
         match self.binary_search_by(|scan_item| f(scan_item, &item)) {


### PR DESCRIPTION
This pr removes the where bound `A: Ord` for the `Vector::insert_ord_by()` function as it is
unnecessary, and the purpose of the function is to make an ordered insert for a `Vector` where the
elements doesn't implement `Ord`. Please add this change to the changelog if you feel it is
necessary.
