### PR TITLE
OrdMap: lift Branch/Leaf enum out of Node

### DIFF
--- a/src/nodes/btree.rs
+++ b/src/nodes/btree.rs
@@ -6,6 +6,7 @@ use std::borrow::Borrow;
 use std::collections::VecDeque;
 use std::iter::FromIterator;
 use std::mem;
+use std::num::NonZeroUsize;
 use std::ops::{Bound, RangeBounds};
 
 use archery::{SharedPointer, SharedPointerKind};
@@ -20,54 +21,75 @@ const NUM_CHILDREN: usize = NODE_SIZE + 1;
 /// A node in a `B+Tree`.
 #[derive(Debug)]
 pub(crate) enum Node<K, V, P: SharedPointerKind> {
-    Branch(Branch<K, V, P>),
-    Leaf(Leaf<K, V>),
+    Branch(SharedPointer<Branch<K, V, P>, P>),
+    Leaf(SharedPointer<Leaf<K, V>, P>),
 }
 
+impl<K: Ord + std::fmt::Debug, V: std::fmt::Debug, P: SharedPointerKind> Branch<K, V, P> {
+    #[cfg(any(test, fuzzing))]
+    pub(crate) fn check_sane(&self, is_root: bool) -> usize {
+        assert!(self.keys.len() >= if is_root { 1 } else { MEDIAN - 1 });
+        assert_eq!(self.keys.len() + 1, self.children.len());
+        assert!(self.keys.windows(2).all(|w| w[0] < w[1]));
+        match &self.children {
+            Children::Leaves { leaves } => {
+                for i in 0..self.keys.len() {
+                    let left = &leaves[i];
+                    let right = &leaves[i + 1];
+                    assert!(left.keys.last().unwrap().0 < right.keys.first().unwrap().0);
+                }
+                leaves.iter().map(|child| child.check_sane(false)).sum()
+            }
+            Children::Branches { branches, level } => {
+                for i in 0..self.keys.len() {
+                    let left = &branches[i];
+                    let right = &branches[i + 1];
+                    assert!(left.level() == level.get() - 1);
+                    assert!(right.level() == level.get() - 1);
+                }
+                branches.iter().map(|child| child.check_sane(false)).sum()
+            }
+        }
+    }
+}
+impl<K: Ord + std::fmt::Debug, V: std::fmt::Debug> Leaf<K, V> {
+    #[cfg(any(test, fuzzing))]
+    pub(crate) fn check_sane(&self, is_root: bool) -> usize {
+        assert!(self.keys.windows(2).all(|w| w[0].0 < w[1].0));
+        assert!(self.keys.len() >= if is_root { 0 } else { THIRD });
+        self.keys.len()
+    }
+}
 impl<K: Ord + std::fmt::Debug, V: std::fmt::Debug, P: SharedPointerKind> Node<K, V, P> {
     /// Check invariants
     #[cfg(any(test, fuzzing))]
     pub(crate) fn check_sane(&self, is_root: bool) -> usize {
         match self {
-            Node::Branch(branch) => {
-                assert!(branch.keys.len() >= if is_root { 1 } else { MEDIAN - 1 });
-                assert_eq!(branch.keys.len() + 1, branch.children.len());
-                assert!(branch.keys.windows(2).all(|w| w[0] < w[1]));
-                for i in 0..branch.keys.len() {
-                    let left = &branch.children[i];
-                    let right = &branch.children[i + 1];
-                    assert!(left.level() == branch.level - 1);
-                    assert!(right.level() == branch.level - 1);
-                    if let (Node::Leaf(left), Node::Leaf(right)) = (&**left, &**right) {
-                        assert!(left.keys.last().unwrap().0 < right.keys.first().unwrap().0);
-                    }
-                }
-                branch
-                    .children
-                    .iter()
-                    .map(|child| child.check_sane(false))
-                    .sum()
-            }
-            Node::Leaf(leaf) => {
-                assert!(leaf.keys.windows(2).all(|w| w[0].0 < w[1].0));
-                assert!(leaf.keys.len() >= if is_root { 0 } else { THIRD });
-                leaf.keys.len()
-            }
+            Node::Branch(branch) => branch.check_sane(is_root),
+            Node::Leaf(leaf) => leaf.check_sane(is_root),
         }
     }
 }
 
 impl<K, V, P: SharedPointerKind> Node<K, V, P> {
     pub(crate) fn unit(key: K, value: V) -> Self {
-        Node::Leaf(Leaf {
+        Node::Leaf(SharedPointer::new(Leaf {
             keys: Chunk::unit((key, value)),
-        })
+        }))
     }
 
     fn level(&self) -> usize {
         match self {
-            Node::Branch(branch) => branch.level,
+            Node::Branch(branch) => branch.level(),
             Node::Leaf(_) => 0,
+        }
+    }
+
+    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Node::Branch(a), Node::Branch(b)) => SharedPointer::ptr_eq(a, b),
+            (Node::Leaf(a), Node::Leaf(b)) => SharedPointer::ptr_eq(a, b),
+            _ => false,
         }
     }
 }
@@ -82,18 +104,152 @@ impl<K, V, P: SharedPointerKind> Node<K, V, P> {
 #[derive(Debug)]
 pub(crate) struct Branch<K, V, P: SharedPointerKind> {
     keys: Chunk<K, NODE_SIZE>,
-    children: Chunk<SharedPointer<Node<K, V, P>, P>, NUM_CHILDREN>,
-    /// The level of the node in the tree, leaves are implicitly the level 0.
-    level: usize,
+    children: Children<K, V, P>,
+}
+
+#[derive(Debug)]
+pub(crate) enum Children<K, V, P: SharedPointerKind> {
+    /// implicitly level 1
+    Leaves {
+        leaves: Chunk<SharedPointer<Leaf<K, V>, P>, NUM_CHILDREN>,
+    },
+    /// level >= 2
+    Branches {
+        branches: Chunk<SharedPointer<Branch<K, V, P>, P>, NUM_CHILDREN>,
+        /// The level of the node in the tree
+        level: NonZeroUsize,
+    },
+}
+
+impl<K, V, P: SharedPointerKind> Children<K, V, P> {
+    fn len(&self) -> usize {
+        match self {
+            Children::Leaves { leaves } => leaves.len(),
+            Children::Branches { branches, .. } => branches.len(),
+        }
+    }
+    fn drain_from_front(&mut self, other: &mut Self, count: usize) {
+        match (self, other) {
+            (
+                Children::Leaves { leaves },
+                Children::Leaves {
+                    leaves: other_leaves,
+                },
+            ) => leaves.drain_from_front(other_leaves, count),
+            (
+                Children::Branches { branches, .. },
+                Children::Branches {
+                    branches: other_branches,
+                    ..
+                },
+            ) => branches.drain_from_front(other_branches, count),
+            _ => panic!("mismatched drain_from_front"),
+        }
+    }
+    fn drain_from_back(&mut self, other: &mut Self, count: usize) {
+        match (self, other) {
+            (
+                Children::Leaves { leaves },
+                Children::Leaves {
+                    leaves: other_leaves,
+                },
+            ) => leaves.drain_from_back(other_leaves, count),
+            (
+                Children::Branches { branches, .. },
+                Children::Branches {
+                    branches: other_branches,
+                    ..
+                },
+            ) => branches.drain_from_back(other_branches, count),
+            _ => panic!("mismatched drain_from_back"),
+        }
+    }
+    fn extend(&mut self, other: &Self) {
+        match (self, other) {
+            (
+                Children::Leaves { leaves },
+                Children::Leaves {
+                    leaves: other_leaves,
+                },
+            ) => leaves.extend(other_leaves.iter().cloned()),
+            (
+                Children::Branches { branches, .. },
+                Children::Branches {
+                    branches: other_branches,
+                    ..
+                },
+            ) => branches.extend(other_branches.iter().cloned()),
+            _ => panic!("mismatched extend"),
+        }
+    }
+    fn insert_front(&mut self, other: &Self) {
+        match (self, other) {
+            (
+                Children::Leaves { leaves },
+                Children::Leaves {
+                    leaves: other_leaves,
+                },
+            ) => leaves.insert_from(0, other_leaves.iter().cloned()),
+            (
+                Children::Branches { branches, .. },
+                Children::Branches {
+                    branches: other_branches,
+                    ..
+                },
+            ) => branches.insert_from(0, other_branches.iter().cloned()),
+            _ => panic!("mismatched insert_front"),
+        }
+    }
+    fn remove(&mut self, index: usize) {
+        match self {
+            Children::Leaves { leaves } => {
+                leaves.remove(index);
+            }
+            Children::Branches { branches, .. } => {
+                branches.remove(index);
+            }
+        }
+    }
+    fn insert(&mut self, index: usize, node: Node<K, V, P>) {
+        match (self, node) {
+            (Children::Leaves { leaves }, Node::Leaf(node)) => leaves.insert(index, node),
+            (Children::Branches { branches, .. }, Node::Branch(node)) => {
+                branches.insert(index, node)
+            }
+            _ => panic!("mismatched insert"),
+        }
+    }
+    fn split_off(&mut self, at: usize) -> Self {
+        match self {
+            Children::Leaves { leaves } => Children::Leaves {
+                leaves: leaves.split_off(at),
+            },
+            Children::Branches { branches, level } => Children::Branches {
+                branches: branches.split_off(at),
+                level: *level,
+            },
+        }
+    }
 }
 
 impl<K, V, P: SharedPointerKind> Branch<K, V, P> {
-    pub(crate) fn pop_single_child(&mut self) -> Option<SharedPointer<Node<K, V, P>, P>> {
+    pub(crate) fn pop_single_child(&mut self) -> Option<Node<K, V, P>> {
         if self.children.len() == 1 {
             debug_assert_eq!(self.keys.len(), 0);
-            return Some(self.children.pop_back());
+            Some(match &mut self.children {
+                Children::Leaves { leaves } => Node::Leaf(leaves.pop_back()),
+                Children::Branches { branches, .. } => Node::Branch(branches.pop_back()),
+            })
+        } else {
+            None
         }
-        None
+    }
+
+    fn level(&self) -> usize {
+        match &self.children {
+            Children::Leaves { .. } => 1,
+            Children::Branches { level, .. } => level.get(),
+        }
     }
 }
 
@@ -117,129 +273,152 @@ impl<K: Ord + Clone, V: Clone, P: SharedPointerKind> Node<K, V, P> {
         K: Borrow<BK>,
     {
         match self {
-            Node::Branch(branch) => {
-                let i = branch
-                    .keys
-                    .binary_search_by(|k| k.borrow().cmp(key))
-                    .map(|x| x + 1)
-                    .unwrap_or_else(|x| x);
-                let child = &mut branch.children[i];
-                if SharedPointer::make_mut(child).remove(key, removed) {
-                    Self::branch_rebalance_children(branch, i);
-                }
-                // Underflow if the branch is < 1/2 full. Since the branches are relatively
-                // rarely rebalanced (given relaxed leaf underflow), we can afford to be
-                // a bit more conservative here.
-                branch.keys.len() < MEDIAN
-            }
-            Node::Leaf(leaf) => {
-                if let Ok(i) = leaf.keys.binary_search_by(|(k, _)| k.borrow().cmp(key)) {
-                    *removed = Some(leaf.keys.remove(i));
-                }
-                // Underflow if the leaf is < 1/3 full. This relaxed underflow (vs. 1/2 full) is
-                // useful to prevent degenerate cases where a random insert/remove workload will
-                // constantly merge/split a leaf.
-                leaf.keys.len() < THIRD
-            }
+            Node::Branch(branch) => SharedPointer::make_mut(branch).remove(key, removed),
+            Node::Leaf(leaf) => SharedPointer::make_mut(leaf).remove(key, removed),
         }
     }
+}
 
-    #[cold]
-    pub(crate) fn branch_rebalance_children(branch: &mut Branch<K, V, P>, underflow_idx: usize) {
-        let left_idx = underflow_idx.saturating_sub(1);
-        let (left, mid, right) = match &branch.children[left_idx..] {
-            [left, mid, right, ..] => (&**left, &**mid, Some(&**right)),
-            [left, mid, ..] => (&**left, &**mid, None),
-            _ => return,
+impl<K: Ord + Clone, V: Clone, P: SharedPointerKind> Branch<K, V, P> {
+    pub(crate) fn remove<BK>(&mut self, key: &BK, removed: &mut Option<(K, V)>) -> bool
+    where
+        BK: Ord + ?Sized,
+        K: Borrow<BK>,
+    {
+        let i = self
+            .keys
+            .binary_search_by(|k| k.borrow().cmp(key))
+            .map(|x| x + 1)
+            .unwrap_or_else(|x| x);
+        let rebalance = match &mut self.children {
+            Children::Leaves { leaves } => {
+                SharedPointer::make_mut(&mut leaves[i]).remove(key, removed)
+            }
+            Children::Branches { branches, .. } => {
+                SharedPointer::make_mut(&mut branches[i]).remove(key, removed)
+            }
         };
-        // Prefer merging two sibling children if we can fit them into a single node.
-        // But also try to rebalance is the smallest child is small (< 1/3), to amortize the cost of rebalancing.
-        // Since we prefer merging, for rebalancing to apply the the largest child will be least 2/3 full,
-        // which results in two at least half full nodes after rebalancing.
-        match (left, mid, right) {
-            (Node::Leaf(left), Node::Leaf(mid), _)
-                if left.keys.len() + mid.keys.len() <= NODE_SIZE =>
-            {
-                Self::merge_leaves(branch, left_idx, false);
+        if rebalance {
+            self.branch_rebalance_children(i);
+        }
+        // Underflow if the branch is < 1/2 full. Since the branches are relatively
+        // rarely rebalanced (given relaxed leaf underflow), we can afford to be
+        // a bit more conservative here.
+        self.keys.len() < MEDIAN
+    }
+}
+
+impl<K: Ord + Clone, V: Clone> Leaf<K, V> {
+    pub(crate) fn remove<BK>(&mut self, key: &BK, removed: &mut Option<(K, V)>) -> bool
+    where
+        BK: Ord + ?Sized,
+        K: Borrow<BK>,
+    {
+        if let Ok(i) = self.keys.binary_search_by(|(k, _)| k.borrow().cmp(key)) {
+            *removed = Some(self.keys.remove(i));
+        }
+        // Underflow if the leaf is < 1/3 full. This relaxed underflow (vs. 1/2 full) is
+        // useful to prevent degenerate cases where a random insert/remove workload will
+        // constantly merge/split a leaf.
+        self.keys.len() < THIRD
+    }
+}
+
+impl<K: Ord + Clone, V: Clone, P: SharedPointerKind> Branch<K, V, P> {
+    #[cold]
+    pub(crate) fn branch_rebalance_children(&mut self, underflow_idx: usize) {
+        let left_idx = underflow_idx.saturating_sub(1);
+        match &mut self.children {
+            Children::Leaves { leaves } => {
+                let (left, mid, right) = match &leaves[left_idx..] {
+                    [left, mid, right, ..] => (&**left, &**mid, Some(&**right)),
+                    [left, mid, ..] => (&**left, &**mid, None),
+                    _ => return,
+                };
+                // Prefer merging two sibling children if we can fit them into a single node.
+                // But also try to rebalance is the smallest child is small (< 1/3), to amortize the cost of rebalancing.
+                // Since we prefer merging, for rebalancing to apply the the largest child will be least 2/3 full,
+                // which results in two at least half full nodes after rebalancing.
+                match (left, mid, right) {
+                    (left, mid, _) if left.keys.len() + mid.keys.len() <= NODE_SIZE => {
+                        self.merge_leaves(left_idx, false);
+                    }
+                    (_, mid, Some(right)) if mid.keys.len() + right.keys.len() <= NODE_SIZE => {
+                        self.merge_leaves(left_idx + 1, true);
+                    }
+                    (left, mid, _) if mid.keys.len().min(left.keys.len()) < THIRD => {
+                        self.rebalance_leaves(left_idx);
+                    }
+                    (_, mid, Some(right)) if mid.keys.len().min(right.keys.len()) < THIRD => {
+                        self.rebalance_leaves(left_idx + 1);
+                    }
+                    _ => (),
+                }
             }
-            (_, Node::Leaf(mid), Some(Node::Leaf(right)))
-                if mid.keys.len() + right.keys.len() <= NODE_SIZE =>
-            {
-                Self::merge_leaves(branch, left_idx + 1, true);
+            Children::Branches { branches, .. } => {
+                let (left, mid, right) = match &branches[left_idx..] {
+                    [left, mid, right, ..] => (&**left, &**mid, Some(&**right)),
+                    [left, mid, ..] => (&**left, &**mid, None),
+                    _ => return,
+                };
+                match (left, mid, right) {
+                    (left, mid, _) if left.keys.len() + mid.keys.len() < NODE_SIZE => {
+                        self.merge_branches(left_idx, false);
+                    }
+                    (_, mid, Some(right)) if mid.keys.len() + right.keys.len() < NODE_SIZE => {
+                        self.merge_branches(left_idx + 1, true);
+                    }
+                    (left, mid, _) if mid.keys.len().min(left.keys.len()) < THIRD => {
+                        self.rebalance_branches(left_idx);
+                    }
+                    (_, mid, Some(right)) if mid.keys.len().min(right.keys.len()) < THIRD => {
+                        self.rebalance_branches(left_idx + 1);
+                    }
+                    _ => (),
+                }
             }
-            (Node::Leaf(left), Node::Leaf(mid), _)
-                if mid.keys.len().min(left.keys.len()) < THIRD =>
-            {
-                Self::rebalance_leaves(branch, left_idx);
-            }
-            (_, Node::Leaf(mid), Some(Node::Leaf(right)))
-                if mid.keys.len().min(right.keys.len()) < THIRD =>
-            {
-                Self::rebalance_leaves(branch, left_idx + 1);
-            }
-            (Node::Branch(left), Node::Branch(mid), _)
-                if left.keys.len() + mid.keys.len() < NODE_SIZE =>
-            {
-                Self::merge_branches(branch, left_idx, false);
-            }
-            (_, Node::Branch(mid), Some(Node::Branch(right)))
-                if mid.keys.len() + right.keys.len() < NODE_SIZE =>
-            {
-                Self::merge_branches(branch, left_idx + 1, true);
-            }
-            (Node::Branch(left), Node::Branch(mid), _)
-                if mid.keys.len().min(left.keys.len()) < THIRD =>
-            {
-                Self::rebalance_branches(branch, left_idx);
-            }
-            (_, Node::Branch(mid), Some(Node::Branch(right)))
-                if mid.keys.len().min(right.keys.len()) < THIRD =>
-            {
-                Self::rebalance_branches(branch, left_idx + 1);
-            }
-            _ => (),
         }
     }
 
     /// Merges two children leaves of this branch.
     ///
     /// Assumes that the two children can fit in a single leaf, panicking if not.
-    fn merge_leaves(branch: &mut Branch<K, V, P>, left_idx: usize, keep_left: bool) {
-        debug_assert_eq!(branch.level, 1);
-        let [left, right, ..] = &mut branch.children[left_idx..] else {
+    fn merge_leaves(&mut self, left_idx: usize, keep_left: bool) {
+        debug_assert_eq!(self.level(), 1);
+        let Children::Leaves { leaves } = &mut self.children else {
+            unreachable!()
+        };
+        let [left, right, ..] = &mut leaves[left_idx..] else {
             unreachable!()
         };
         if keep_left {
             let left = SharedPointer::make_mut(left);
-            let (Node::Leaf(left), Node::Leaf(right)) = (left, &**right) else {
-                unreachable!()
-            };
+            let (left, right) = (left, &**right);
             left.keys.extend(right.keys.iter().cloned());
         } else {
             let right = SharedPointer::make_mut(right);
-            let (Node::Leaf(left), Node::Leaf(right)) = (&**left, right) else {
-                unreachable!()
-            };
+            let (left, right) = (&**left, right);
             right.keys.insert_from(0, left.keys.iter().cloned());
         }
-        branch.keys.remove(left_idx);
-        branch.children.remove(left_idx + (keep_left as usize));
-        debug_assert_eq!(branch.keys.len() + 1, branch.children.len());
+        self.keys.remove(left_idx);
+        leaves.remove(left_idx + (keep_left as usize));
+        debug_assert_eq!(self.keys.len() + 1, self.children.len());
     }
 
     /// Assuming `branch` is at level 1, rebalances two adjacent leaves so that they have the same
     /// number of keys (or differ by at most 1).
-    fn rebalance_leaves(branch: &mut Branch<K, V, P>, left_idx: usize) {
-        debug_assert_eq!(branch.level, 1);
-        let [left, right, ..] = &mut branch.children[left_idx..] else {
+    fn rebalance_leaves(&mut self, left_idx: usize) {
+        debug_assert_eq!(self.level(), 1);
+        let Children::Leaves { leaves } = &mut self.children else {
             unreachable!()
         };
-        let (Node::Leaf(left), Node::Leaf(right)) = (
+        let [left, right, ..] = &mut leaves[left_idx..] else {
+            unreachable!()
+        };
+        let (left, right) = (
             SharedPointer::make_mut(left),
             SharedPointer::make_mut(right),
-        ) else {
-            unreachable!()
-        };
+        );
         let num_to_move = left.keys.len().abs_diff(right.keys.len()) / 2;
         if num_to_move == 0 {
             return;
@@ -249,7 +428,7 @@ impl<K: Ord + Clone, V: Clone, P: SharedPointerKind> Node<K, V, P> {
         } else {
             left.keys.drain_from_front(&mut right.keys, num_to_move);
         }
-        branch.keys[left_idx] = right.keys.first().unwrap().0.clone();
+        self.keys[left_idx] = right.keys.first().unwrap().0.clone();
         debug_assert_ne!(left.keys.len(), 0);
         debug_assert_ne!(right.keys.len(), 0);
     }
@@ -257,21 +436,22 @@ impl<K: Ord + Clone, V: Clone, P: SharedPointerKind> Node<K, V, P> {
     /// Rebalances two adjacent child branches so that they have the same number of keys
     /// (or differ by at most 1). The separator key is rotated between the two branches.
     /// to keep the invariants of the parent branch.
-    fn rebalance_branches(branch: &mut Branch<K, V, P>, left_idx: usize) {
-        let [left, right, ..] = &mut branch.children[left_idx..] else {
+    fn rebalance_branches(self: &mut Branch<K, V, P>, left_idx: usize) {
+        let Children::Branches { branches, .. } = &mut self.children else {
             unreachable!()
         };
-        let (Node::Branch(left), Node::Branch(right)) = (
+        let [left, right, ..] = &mut branches[left_idx..] else {
+            unreachable!()
+        };
+        let (left, right) = (
             SharedPointer::make_mut(left),
             SharedPointer::make_mut(right),
-        ) else {
-            unreachable!()
-        };
+        );
         let num_to_move = left.keys.len().abs_diff(right.keys.len()) / 2;
         if num_to_move == 0 {
             return;
         }
-        let separator = &mut branch.keys[left_idx];
+        let separator = &mut self.keys[left_idx];
         if left.keys.len() > right.keys.len() {
             right.keys.push_front(separator.clone());
             right.keys.drain_from_back(&mut left.keys, num_to_move - 1);
@@ -295,178 +475,277 @@ impl<K: Ord + Clone, V: Clone, P: SharedPointerKind> Node<K, V, P> {
     /// Merges two children of this branch.
     ///
     /// Assumes that the two children can fit in a single branch, panicking if not.
-    fn merge_branches(branch: &mut Branch<K, V, P>, left_idx: usize, keep_left: bool) {
-        debug_assert!(branch.level >= 2);
-        let [left, right, ..] = &mut branch.children[left_idx..] else {
+    fn merge_branches(&mut self, left_idx: usize, keep_left: bool) {
+        debug_assert!(self.level() >= 2);
+        let Children::Branches { branches, .. } = &mut self.children else {
             unreachable!()
         };
-        let separator = branch.keys.remove(left_idx);
+        let [left, right, ..] = &mut branches[left_idx..] else {
+            unreachable!()
+        };
+        let separator = self.keys.remove(left_idx);
         if keep_left {
             let left = SharedPointer::make_mut(left);
-            let (Node::Branch(left), Node::Branch(right)) = (left, &**right) else {
-                unreachable!()
-            };
+            let (left, right) = (left, &**right);
             left.keys.push_back(separator);
             left.keys.extend(right.keys.iter().cloned());
-            left.children.extend(right.children.iter().cloned());
+            left.children.extend(&right.children);
         } else {
             let right = SharedPointer::make_mut(right);
-            let (Node::Branch(left), Node::Branch(right)) = (&**left, right) else {
-                unreachable!()
-            };
+            let (left, right) = (&**left, right);
             right.keys.push_front(separator);
             right.keys.insert_from(0, left.keys.iter().cloned());
-            right.children.insert_from(0, left.children.iter().cloned());
+            right.children.insert_front(&left.children);
         }
-        branch.children.remove(left_idx + (keep_left as usize));
-        debug_assert_eq!(branch.keys.len() + 1, branch.children.len());
+        self.children.remove(left_idx + (keep_left as usize));
+        debug_assert_eq!(self.keys.len() + 1, self.children.len());
     }
+}
 
+impl<K: Ord + Clone, V: Clone, P: SharedPointerKind> Branch<K, V, P> {
+    pub(crate) fn insert(&mut self, key: K, value: V) -> InsertAction<K, V, P> {
+        let i = self
+            .keys
+            .binary_search(&key)
+            .map(|x| x + 1)
+            .unwrap_or_else(|x| x);
+        let insert_action = match &mut self.children {
+            Children::Leaves { leaves } => {
+                SharedPointer::make_mut(&mut leaves[i]).insert(key, value)
+            }
+            Children::Branches { branches, .. } => {
+                SharedPointer::make_mut(&mut branches[i]).insert(key, value)
+            }
+        };
+        match insert_action {
+            InsertAction::Split(new_key, new_node) if self.keys.len() >= NODE_SIZE => {
+                self.split_branch_insert(i, new_key, new_node)
+            }
+            InsertAction::Split(separator, new_node) => {
+                self.keys.insert(i, separator);
+                self.children.insert(i + 1, new_node);
+                InsertAction::Inserted
+            }
+            action => action,
+        }
+    }
+}
+impl<K: Ord + Clone, V: Clone> Leaf<K, V> {
+    pub(crate) fn insert<P: SharedPointerKind>(
+        &mut self,
+        key: K,
+        value: V,
+    ) -> InsertAction<K, V, P> {
+        match self.keys.binary_search_by(|(k, _)| k.cmp(&key)) {
+            Ok(i) => {
+                let (k, v) = mem::replace(&mut self.keys[i], (key, value));
+                InsertAction::Replaced(k, v)
+            }
+            Err(i) if self.keys.len() >= NODE_SIZE => self.split_leaf_insert(i, key, value),
+            Err(i) => {
+                self.keys.insert(i, (key, value));
+                InsertAction::Inserted
+            }
+        }
+    }
+}
+impl<K: Ord + Clone, V: Clone, P: SharedPointerKind> Node<K, V, P> {
     pub(crate) fn insert(&mut self, key: K, value: V) -> InsertAction<K, V, P> {
         match self {
-            Node::Branch(branch) => {
-                let i = branch
-                    .keys
-                    .binary_search(&key)
-                    .map(|x| x + 1)
-                    .unwrap_or_else(|x| x);
-                match SharedPointer::make_mut(&mut branch.children[i]).insert(key, value) {
-                    InsertAction::Split(new_key, new_node) if branch.keys.len() >= NODE_SIZE => {
-                        Self::split_branch_insert(branch, i, new_key, new_node)
-                    }
-                    InsertAction::Split(separator, new_node) => {
-                        branch.keys.insert(i, separator);
-                        branch.children.insert(i + 1, new_node);
-                        InsertAction::Inserted
-                    }
-                    action => action,
-                }
-            }
-            Node::Leaf(leaf) => match leaf.keys.binary_search_by(|(k, _)| k.cmp(&key)) {
-                Ok(i) => {
-                    let (k, v) = mem::replace(&mut leaf.keys[i], (key, value));
-                    InsertAction::Replaced(k, v)
-                }
-                Err(i) if leaf.keys.len() >= NODE_SIZE => {
-                    Self::split_leaf_insert(leaf, i, key, value)
-                }
-                Err(i) => {
-                    leaf.keys.insert(i, (key, value));
-                    InsertAction::Inserted
-                }
-            },
+            Node::Branch(branch) => SharedPointer::make_mut(branch).insert(key, value),
+            Node::Leaf(leaf) => SharedPointer::make_mut(leaf).insert(key, value),
         }
     }
-
+}
+impl<K: Ord + Clone, V: Clone, P: SharedPointerKind> Branch<K, V, P> {
     #[cold]
     fn split_branch_insert(
-        branch: &mut Branch<K, V, P>,
+        &mut self,
         i: usize,
         new_key: K,
-        new_node: SharedPointer<Node<K, V, P>, P>,
+        new_node: Node<K, V, P>,
     ) -> InsertAction<K, V, P> {
         let split_idx = MEDIAN + (i > MEDIAN) as usize;
-        let mut right_keys = branch.keys.split_off(split_idx);
+        let mut right_keys = self.keys.split_off(split_idx);
         let split_idx = MEDIAN + (i >= MEDIAN) as usize;
-        let mut right_children = branch.children.split_off(split_idx);
+        let mut right_children = self.children.split_off(split_idx);
         let separator = if i == MEDIAN {
-            right_children.push_front(new_node.clone());
+            right_children.insert(0, new_node.clone());
             new_key
         } else {
             if i < MEDIAN {
-                branch.keys.insert(i, new_key);
-                branch.children.insert(i + 1, new_node);
+                self.keys.insert(i, new_key);
+                self.children.insert(i + 1, new_node);
             } else {
                 right_keys.insert(i - (MEDIAN + 1), new_key);
                 right_children.insert(i - (MEDIAN + 1) + 1, new_node);
             }
-            branch.keys.pop_back()
+            self.keys.pop_back()
         };
-        debug_assert_eq!(branch.keys.len(), right_keys.len());
-        debug_assert_eq!(branch.keys.len() + 1, branch.children.len());
+        debug_assert_eq!(self.keys.len(), right_keys.len());
+        debug_assert_eq!(self.keys.len() + 1, self.children.len());
         debug_assert_eq!(right_keys.len() + 1, right_children.len());
         InsertAction::Split(
             separator,
-            SharedPointer::new(Node::Branch(Branch {
-                level: branch.level,
+            Node::Branch(SharedPointer::new(Branch {
                 keys: right_keys,
                 children: right_children,
             })),
         )
     }
+}
 
+impl<K: Ord + Clone, V: Clone> Leaf<K, V> {
     #[inline]
-    fn split_leaf_insert(
-        leaf: &mut Leaf<K, V>,
+    fn split_leaf_insert<P: SharedPointerKind>(
+        &mut self,
         i: usize,
         key: K,
         value: V,
     ) -> InsertAction<K, V, P> {
-        let mut right_keys = leaf.keys.split_off(MEDIAN);
+        let mut right_keys = self.keys.split_off(MEDIAN);
         if i < MEDIAN {
-            leaf.keys.insert(i, (key, value));
+            self.keys.insert(i, (key, value));
         } else {
             right_keys.insert(i - MEDIAN, (key, value));
         }
         InsertAction::Split(
             right_keys.first().unwrap().0.clone(),
-            SharedPointer::new(Node::Leaf(Leaf { keys: right_keys })),
+            Node::Leaf(SharedPointer::new(Leaf { keys: right_keys })),
         )
     }
+}
 
+impl<K: Ord + Clone, V: Clone, P: SharedPointerKind> Branch<K, V, P> {
+    pub(crate) fn lookup_mut<BK>(&mut self, key: &BK) -> Option<(&K, &mut V)>
+    where
+        BK: Ord + ?Sized,
+        K: Borrow<BK>,
+    {
+        let i = self
+            .keys
+            .binary_search_by(|k| k.borrow().cmp(key))
+            .map(|x| x + 1)
+            .unwrap_or_else(|x| x);
+        match &mut self.children {
+            Children::Leaves { leaves } => SharedPointer::make_mut(&mut leaves[i]).lookup_mut(key),
+            Children::Branches { branches, .. } => {
+                SharedPointer::make_mut(&mut branches[i]).lookup_mut(key)
+            }
+        }
+    }
+}
+
+impl<K: Ord + Clone, V: Clone> Leaf<K, V> {
+    pub(crate) fn lookup_mut<BK>(&mut self, key: &BK) -> Option<(&K, &mut V)>
+    where
+        BK: Ord + ?Sized,
+        K: Borrow<BK>,
+    {
+        let keys = &mut self.keys;
+        let i = keys.binary_search_by(|(k, _)| k.borrow().cmp(key)).ok()?;
+        keys.get_mut(i).map(|(k, v)| (&*k, v))
+    }
+}
+
+impl<K: Ord + Clone, V: Clone, P: SharedPointerKind> Node<K, V, P> {
     pub(crate) fn lookup_mut<BK>(&mut self, key: &BK) -> Option<(&K, &mut V)>
     where
         BK: Ord + ?Sized,
         K: Borrow<BK>,
     {
         match self {
-            Node::Branch(branch) => {
-                let i = branch
-                    .keys
-                    .binary_search_by(|k| k.borrow().cmp(key))
-                    .map(|x| x + 1)
-                    .unwrap_or_else(|x| x);
-                SharedPointer::make_mut(&mut branch.children[i]).lookup_mut(key)
-            }
-            Node::Leaf(leaf) => {
-                let keys = &mut leaf.keys;
-                let i = keys.binary_search_by(|(k, _)| k.borrow().cmp(key)).ok()?;
-                keys.get_mut(i).map(|(k, v)| (&*k, v))
-            }
+            Node::Branch(branch) => SharedPointer::make_mut(branch).lookup_mut(key),
+            Node::Leaf(leaf) => SharedPointer::make_mut(leaf).lookup_mut(key),
         }
     }
 
-    pub(crate) fn new_from_split(
-        left: SharedPointer<Self, P>,
-        separator: K,
-        right: SharedPointer<Self, P>,
-    ) -> Self {
-        Node::Branch(Branch {
-            level: left.level() + 1,
+    pub(crate) fn new_from_split(left: Self, separator: K, right: Self) -> Self {
+        Node::Branch(SharedPointer::new(Branch {
             keys: Chunk::unit(separator),
-            children: Chunk::from_iter([left, right]),
-        })
+            children: match (left, right) {
+                (Node::Branch(left), Node::Branch(right)) => Children::Branches {
+                    level: NonZeroUsize::new(left.level() + 1).unwrap(),
+                    branches: Chunk::from_iter([left, right]),
+                },
+                (Node::Leaf(left), Node::Leaf(right)) => Children::Leaves {
+                    leaves: Chunk::from_iter([left, right]),
+                },
+                _ => panic!("mismatched split"),
+            },
+        }))
+    }
+}
+
+impl<K: Ord, V, P: SharedPointerKind> Branch<K, V, P> {
+    fn min(&self) -> Option<&(K, V)> {
+        let mut node = self;
+        loop {
+            match &node.children {
+                Children::Leaves { leaves } => return leaves.first()?.min(),
+                Children::Branches { branches, .. } => node = branches.first()?,
+            }
+        }
+    }
+    fn max(&self) -> Option<&(K, V)> {
+        let mut node = self;
+        loop {
+            match &node.children {
+                Children::Leaves { leaves } => return leaves.last()?.max(),
+                Children::Branches { branches, .. } => node = branches.last()?,
+            }
+        }
+    }
+    pub(crate) fn lookup<BK>(&self, key: &BK) -> Option<&(K, V)>
+    where
+        BK: Ord + ?Sized,
+        K: Borrow<BK>,
+    {
+        let mut node = self;
+        loop {
+            let i = node
+                .keys
+                .binary_search_by(|k| k.borrow().cmp(key))
+                .map(|x| x + 1)
+                .unwrap_or_else(|x| x);
+            match &node.children {
+                Children::Leaves { leaves } => return leaves[i].lookup(key),
+                Children::Branches { branches, .. } => node = &branches[i],
+            }
+        }
+    }
+}
+
+impl<K: Ord, V> Leaf<K, V> {
+    fn min(&self) -> Option<&(K, V)> {
+        self.keys.first()
+    }
+    fn max(&self) -> Option<&(K, V)> {
+        self.keys.last()
+    }
+    fn lookup<BK>(&self, key: &BK) -> Option<&(K, V)>
+    where
+        BK: Ord + ?Sized,
+        K: Borrow<BK>,
+    {
+        let keys = &self.keys;
+        let i = keys.binary_search_by(|(k, _)| k.borrow().cmp(key)).ok()?;
+        keys.get(i)
     }
 }
 
 impl<K: Ord, V, P: SharedPointerKind> Node<K, V, P> {
     pub(crate) fn min(&self) -> Option<&(K, V)> {
-        let mut node = self;
-        loop {
-            node = match node {
-                Node::Branch(branch) => &branch.children[0],
-                Node::Leaf(leaf) => return leaf.keys.first(),
-            };
+        match self {
+            Node::Branch(branch) => branch.min(),
+            Node::Leaf(leaf) => leaf.min(),
         }
     }
 
     pub(crate) fn max(&self) -> Option<&(K, V)> {
-        let mut node = self;
-        loop {
-            node = match node {
-                Node::Branch(branch) => &branch.children[branch.children.len() - 1],
-                Node::Leaf(leaf) => return leaf.keys.last(),
-            };
+        match self {
+            Node::Branch(branch) => branch.max(),
+            Node::Leaf(leaf) => leaf.max(),
         }
     }
 
@@ -475,23 +754,9 @@ impl<K: Ord, V, P: SharedPointerKind> Node<K, V, P> {
         BK: Ord + ?Sized,
         K: Borrow<BK>,
     {
-        let mut node = self;
-        loop {
-            match node {
-                Node::Branch(branch) => {
-                    let i = branch
-                        .keys
-                        .binary_search_by(|k| k.borrow().cmp(key))
-                        .map(|x| x + 1)
-                        .unwrap_or_else(|x| x);
-                    node = &branch.children[i];
-                }
-                Node::Leaf(leaf) => {
-                    let keys = &leaf.keys;
-                    let i = keys.binary_search_by(|(k, _)| k.borrow().cmp(key)).ok()?;
-                    return keys.get(i);
-                }
-            }
+        match self {
+            Node::Branch(branch) => branch.lookup(key),
+            Node::Leaf(leaf) => leaf.lookup(key),
         }
     }
 }
@@ -509,12 +774,25 @@ impl<K: Clone, V: Clone, P: SharedPointerKind> Clone for Branch<K, V, P> {
         Self {
             keys: self.keys.clone(),
             children: self.children.clone(),
-            level: self.level,
         }
     }
 }
 
-impl<K: Clone, V: Clone, P: SharedPointerKind> Clone for Node<K, V, P> {
+impl<K: Clone, V: Clone, P: SharedPointerKind> Clone for Children<K, V, P> {
+    fn clone(&self) -> Self {
+        match self {
+            Children::Leaves { leaves } => Children::Leaves {
+                leaves: leaves.clone(),
+            },
+            Children::Branches { branches, level } => Children::Branches {
+                branches: branches.clone(),
+                level: *level,
+            },
+        }
+    }
+}
+
+impl<K, V, P: SharedPointerKind> Clone for Node<K, V, P> {
     fn clone(&self) -> Self {
         match self {
             Node::Branch(branch) => Node::Branch(branch.clone()),
@@ -526,12 +804,12 @@ impl<K: Clone, V: Clone, P: SharedPointerKind> Clone for Node<K, V, P> {
 pub(crate) enum InsertAction<K, V, P: SharedPointerKind> {
     Inserted,
     Replaced(K, V),
-    Split(K, SharedPointer<Node<K, V, P>, P>),
+    Split(K, Node<K, V, P>),
 }
 
 impl<K, V, P: SharedPointerKind> Default for Node<K, V, P> {
     fn default() -> Self {
-        Node::Leaf(Leaf { keys: Chunk::new() })
+        Node::Leaf(SharedPointer::new(Leaf { keys: Chunk::new() }))
     }
 }
 
@@ -541,34 +819,31 @@ pub(crate) struct ConsumingIter<K, V, P: SharedPointerKind> {
     /// as it will allows us to have a smaller VecDeque allocation and avoid eagerly
     /// cloning the leaves, which defeats the purpose of this iterator.
     /// Leaves present in the VecDeque are guaranteed to be non-empty.
-    leaves: VecDeque<SharedPointer<Node<K, V, P>, P>>,
+    leaves: VecDeque<SharedPointer<Leaf<K, V>, P>>,
     remaining: usize,
 }
 
 impl<K, V, P: SharedPointerKind> ConsumingIter<K, V, P> {
-    pub(crate) fn new(node: Option<SharedPointer<Node<K, V, P>, P>>, size: usize) -> Self {
+    pub(crate) fn new(node: Option<Node<K, V, P>>, size: usize) -> Self {
         fn push<K, V, P: SharedPointerKind>(
-            leaves: &mut VecDeque<SharedPointer<Node<K, V, P>, P>>,
-            node: SharedPointer<Node<K, V, P>, P>,
+            out: &mut VecDeque<SharedPointer<Leaf<K, V>, P>>,
+            node: SharedPointer<Branch<K, V, P>, P>,
         ) {
-            match &*node {
-                Node::Branch(branch) => {
-                    if branch.level == 1 {
-                        leaves.extend(branch.children.iter().cloned());
-                    } else {
-                        for child in branch.children.iter() {
-                            push(leaves, child.clone());
-                        }
+            match &node.children {
+                Children::Leaves { leaves } => out.extend(leaves.iter().cloned()),
+                Children::Branches { branches, .. } => {
+                    for child in branches.iter() {
+                        push(out, child.clone());
                     }
                 }
-                Node::Leaf(leaf) if !leaf.keys.is_empty() => leaves.push_back(node),
-                Node::Leaf(_) => (),
             }
         }
         // preallocate the VecDeque assuming each leaf is half full
         let mut leaves = VecDeque::with_capacity(size.div_ceil(NODE_SIZE / 2));
-        if let Some(node) = node {
-            push(&mut leaves, node);
+        match node {
+            Some(Node::Branch(b)) => push(&mut leaves, b),
+            Some(Node::Leaf(l)) => leaves.push_back(l),
+            None => (),
         }
         Self {
             leaves,
@@ -582,9 +857,7 @@ impl<K: Clone, V: Clone, P: SharedPointerKind> Iterator for ConsumingIter<K, V, 
 
     fn next(&mut self) -> Option<Self::Item> {
         let node = self.leaves.front_mut()?;
-        let Node::Leaf(leaf) = SharedPointer::make_mut(node) else {
-            unreachable!()
-        };
+        let leaf = SharedPointer::make_mut(node);
         self.remaining -= 1;
         let item = leaf.keys.pop_front();
         if leaf.keys.is_empty() {
@@ -601,9 +874,7 @@ impl<K: Clone, V: Clone, P: SharedPointerKind> Iterator for ConsumingIter<K, V, 
 impl<K: Clone, V: Clone, P: SharedPointerKind> DoubleEndedIterator for ConsumingIter<K, V, P> {
     fn next_back(&mut self) -> Option<Self::Item> {
         let node = self.leaves.back_mut()?;
-        let Node::Leaf(leaf) = SharedPointer::make_mut(node) else {
-            unreachable!()
-        };
+        let leaf = SharedPointer::make_mut(node);
         self.remaining -= 1;
         let item = leaf.keys.pop_back();
         if leaf.keys.is_empty() {
@@ -643,7 +914,7 @@ impl<'a, K, V, P: SharedPointerKind> Iter<'a, K, V, P> {
                 {
                     fwd.next().is_none()
                 } else {
-                    fwd.stack.is_empty()
+                    fwd.is_empty()
                 }
             }
             Bound::Unbounded => false,
@@ -655,7 +926,7 @@ impl<'a, K, V, P: SharedPointerKind> Iter<'a, K, V, P> {
                 if bwd.seek_to_key(key, true) && matches!(range.end_bound(), Bound::Excluded(_)) {
                     bwd.prev().is_none()
                 } else {
-                    bwd.stack.is_empty()
+                    bwd.is_empty()
                 }
             }
             (exhausted, _) => exhausted,
@@ -663,15 +934,29 @@ impl<'a, K, V, P: SharedPointerKind> Iter<'a, K, V, P> {
 
         // Check if forward is > backward cursor to determine if we are exhausted
         // Due to the usage of zip this is correct even if the cursors are already or not initialized yet
-        for (&(fi, f), &(bi, b)) in fwd.stack.iter().zip(bwd.stack.iter()) {
-            if !std::ptr::addr_eq(f, b) {
-                break;
+        fn cursors_exhausted<K, V, P: SharedPointerKind>(
+            fwd: &Cursor<'_, K, V, P>,
+            bwd: &Cursor<'_, K, V, P>,
+        ) -> bool {
+            for (&(fi, f), &(bi, b)) in fwd.stack.iter().zip(bwd.stack.iter()) {
+                if !std::ptr::eq(f, b) {
+                    return false;
+                }
+                if fi > bi {
+                    return true;
+                }
             }
-            if fi > bi {
-                exhausted = true;
-                break;
+            if let (Some((fi, f)), Some((bi, b))) = (fwd.leaf, bwd.leaf) {
+                if !std::ptr::eq(f, b) {
+                    return false;
+                }
+                if fi > bi {
+                    return true;
+                }
             }
+            false
         }
+        exhausted = exhausted || cursors_exhausted(&fwd, &bwd);
 
         let exact = matches!(range.start_bound(), Bound::Unbounded)
             && matches!(range.end_bound(), Bound::Unbounded);
@@ -701,8 +986,8 @@ impl<'a, K, V, P: SharedPointerKind> Iter<'a, K, V, P> {
         // Check if the cursors are exhausted by checking their leaves
         // This is valid even if the cursors are empty due to not being initialized yet.
         // If they were empty because exhaustion we would not be in this function.
-        if let (Some(&(fi, f)), Some(&(bi, b))) = (self.fwd.stack.last(), self.bwd.stack.last()) {
-            if std::ptr::addr_eq(f, b) && fi >= bi {
+        if let (Some((fi, f)), Some((bi, b))) = (self.fwd.leaf, self.bwd.leaf) {
+            if std::ptr::eq(f, b) && fi >= bi {
                 self.exhausted = true;
                 return fi == bi && other_side_yielded;
             }
@@ -722,7 +1007,7 @@ impl<'a, K, V, P: SharedPointerKind> Iter<'a, K, V, P> {
         };
         // If the cursor is empty we need to initialize it and seek to the first/last element.
         // If they were empty because exhaustion we would not be in this function.
-        if cursor.stack.is_empty() {
+        if cursor.is_empty() {
             cursor.init(self.root);
             if fwd {
                 cursor.seek_to_first();
@@ -799,13 +1084,16 @@ impl<'a, K, V, P: SharedPointerKind> Clone for Iter<'a, K, V, P> {
 
 #[derive(Debug)]
 pub(crate) struct Cursor<'a, K, V, P: SharedPointerKind> {
-    stack: Vec<(usize, &'a Node<K, V, P>)>,
+    // a sequence of nodes starting at the root
+    stack: Vec<(usize, &'a Branch<K, V, P>)>,
+    leaf: Option<(usize, &'a Leaf<K, V>)>,
 }
 
 impl<'a, K, V, P: SharedPointerKind> Clone for Cursor<'a, K, V, P> {
     fn clone(&self) -> Self {
         Self {
             stack: self.stack.clone(),
+            leaf: self.leaf.clone(),
         }
     }
 }
@@ -815,45 +1103,71 @@ impl<'a, K, V, P: SharedPointerKind> Cursor<'a, K, V, P> {
     /// The variety of methods is to allow for a more efficient initialization
     /// in all cases.
     pub(crate) fn empty() -> Self {
-        Self { stack: Vec::new() }
+        Self {
+            stack: Vec::new(),
+            leaf: None,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.stack.is_empty() && self.leaf.is_none()
     }
 
     pub(crate) fn init(&mut self, node: Option<&'a Node<K, V, P>>) {
         if let Some(node) = node {
-            self.stack.reserve_exact(node.level() + 1);
-            self.stack.push((0, node));
+            self.stack.reserve_exact(node.level());
+            match node {
+                Node::Branch(branch) => self.stack.push((0, &*branch)),
+                Node::Leaf(leaf) => {
+                    debug_assert!(self.leaf.is_none());
+                    self.leaf = Some((0, &*leaf))
+                }
+            }
+        }
+    }
+
+    // pushes the `ix`th child of `branch` onto the stack, whether it's a leaf
+    // or a branch
+    fn push_child(&mut self, branch: &'a Branch<K, V, P>, ix: usize) {
+        debug_assert!(
+            self.leaf.is_none(),
+            "it doesn't make sense to push when we're already at a leaf"
+        );
+        match &branch.children {
+            Children::Leaves { leaves } => self.leaf = Some((0, &leaves[ix])),
+            Children::Branches { branches, .. } => self.stack.push((0, &branches[ix])),
         }
     }
 
     pub(crate) fn seek_to_first(&mut self) -> Option<&'a (K, V)> {
-        while let Some((i, node)) = self.stack.last_mut() {
-            debug_assert_eq!(i, &0);
-            match node {
-                Node::Branch(branch) => {
-                    self.stack.push((0, &branch.children[0]));
-                }
-                Node::Leaf(leaf) => return leaf.keys.first(),
+        loop {
+            if let Some((i, leaf)) = &self.leaf {
+                debug_assert_eq!(i, &0);
+                return leaf.keys.first();
             }
+            let Some((i, branch)) = self.stack.last() else {
+                return None;
+            };
+            debug_assert_eq!(i, &0);
+            self.push_child(branch, 0);
         }
-        None
     }
 
     fn seek_to_last(&mut self) -> Option<&'a (K, V)> {
-        while let Some((i, node)) = self.stack.last_mut() {
-            debug_assert_eq!(i, &0);
-            match node {
-                Node::Branch(branch) => {
-                    *i = branch.children.len() - 1;
-                    let child = &branch.children[*i];
-                    self.stack.push((0, child));
-                }
-                Node::Leaf(leaf) => {
-                    *i = leaf.keys.len().saturating_sub(1);
-                    return leaf.keys.last();
-                }
+        loop {
+            if let Some((i, leaf)) = &mut self.leaf {
+                debug_assert_eq!(i, &0);
+                *i = leaf.keys.len().saturating_sub(1);
+                return leaf.keys.last();
             }
+            let Some((i, branch)) = self.stack.last_mut() else {
+                return None;
+            };
+            debug_assert_eq!(i, &0);
+            *i = branch.children.len() - 1;
+            let (i, branch) = (*i, *branch);
+            self.push_child(branch, i);
         }
-        None
     }
 
     fn seek_to_key<BK>(&mut self, key: &BK, for_prev: bool) -> bool
@@ -861,32 +1175,30 @@ impl<'a, K, V, P: SharedPointerKind> Cursor<'a, K, V, P> {
         BK: Ord + ?Sized,
         K: Borrow<BK>,
     {
-        while let Some((i, node)) = self.stack.last_mut() {
-            match node {
-                Node::Branch(branch) => {
-                    *i = branch
-                        .keys
-                        .binary_search_by(|k| k.borrow().cmp(key))
-                        .map(|x| x + 1)
-                        .unwrap_or_else(|x| x);
-                    let child = &branch.children[*i];
-                    self.stack.push((0, child));
-                }
-                Node::Leaf(leaf) => {
-                    let search = leaf.keys.binary_search_by(|(k, _)| k.borrow().cmp(key));
-                    *i = search.unwrap_or_else(|x| x);
-                    if for_prev {
-                        if search.is_err() {
-                            self.prev();
-                        }
-                    } else if search == Err(leaf.keys.len()) {
-                        self.next();
+        loop {
+            if let Some((i, leaf)) = &mut self.leaf {
+                let search = leaf.keys.binary_search_by(|(k, _)| k.borrow().cmp(key));
+                *i = search.unwrap_or_else(|x| x);
+                if for_prev {
+                    if search.is_err() {
+                        self.prev();
                     }
-                    return search.is_ok();
+                } else if search == Err(leaf.keys.len()) {
+                    self.next();
                 }
+                return search.is_ok();
             }
+            let Some((i, branch)) = self.stack.last_mut() else {
+                return false;
+            };
+            *i = branch
+                .keys
+                .binary_search_by(|k| k.borrow().cmp(key))
+                .map(|x| x + 1)
+                .unwrap_or_else(|x| x);
+            let (i, branch) = (*i, *branch);
+            self.push_child(branch, i);
         }
-        false
     }
 
     /// Advances this and another cursor to their next position.
@@ -896,42 +1208,52 @@ impl<'a, K, V, P: SharedPointerKind> Cursor<'a, K, V, P> {
         // before skipping them. But it requires very little additional code.
         // Nevertheless it will still improve performance when there are shared nodes.
         loop {
-            let shared_levels = self
-                .stack
-                .iter()
-                .rev()
-                .zip(other.stack.iter().rev())
-                .take_while(|(this, that)| std::ptr::addr_eq(this.1, that.1))
-                .count();
-            if shared_levels != 0 {
-                self.stack.drain(self.stack.len() - shared_levels..);
-                other.stack.drain(other.stack.len() - shared_levels..);
+            let mut skipped_any = false;
+            debug_assert!(self.leaf.is_some());
+            debug_assert!(other.leaf.is_some());
+            if let (Some(this), Some(that)) = (self.leaf, other.leaf) {
+                if std::ptr::eq(this.1, that.1) {
+                    self.leaf = None;
+                    other.leaf = None;
+                    skipped_any = true;
+                    let shared_levels = self
+                        .stack
+                        .iter()
+                        .rev()
+                        .zip(other.stack.iter().rev())
+                        .take_while(|(this, that)| std::ptr::eq(this.1, that.1))
+                        .count();
+                    if shared_levels != 0 {
+                        self.stack.drain(self.stack.len() - shared_levels..);
+                        other.stack.drain(other.stack.len() - shared_levels..);
+                    }
+                }
             }
             self.next();
             other.next();
-            if shared_levels == 0 {
+            if !skipped_any || self.leaf.is_none() {
                 break;
             }
         }
     }
 
     pub(crate) fn next(&mut self) -> Option<&'a (K, V)> {
-        while let Some((i, node)) = self.stack.last_mut() {
-            match node {
-                Node::Branch(branch) => {
-                    if *i + 1 < branch.children.len() {
-                        *i += 1;
-                        let child = &branch.children[*i];
-                        self.stack.push((0, child));
-                        break;
-                    }
+        loop {
+            if let Some((i, leaf)) = &mut self.leaf {
+                if *i + 1 < leaf.keys.len() {
+                    *i += 1;
+                    return leaf.keys.get(*i);
                 }
-                Node::Leaf(leaf) => {
-                    if *i + 1 < leaf.keys.len() {
-                        *i += 1;
-                        return leaf.keys.get(*i);
-                    }
-                }
+                self.leaf = None;
+            }
+            let Some((i, branch)) = self.stack.last_mut() else {
+                break;
+            };
+            if *i + 1 < branch.children.len() {
+                *i += 1;
+                let (i, branch) = (*i, *branch);
+                self.push_child(branch, i);
+                break;
             }
             self.stack.pop();
         }
@@ -939,22 +1261,22 @@ impl<'a, K, V, P: SharedPointerKind> Cursor<'a, K, V, P> {
     }
 
     fn prev(&mut self) -> Option<&'a (K, V)> {
-        while let Some((i, node)) = self.stack.last_mut() {
-            match node {
-                Node::Branch(branch) => {
-                    if *i > 0 {
-                        *i -= 1;
-                        let child = &branch.children[*i];
-                        self.stack.push((0, child));
-                        break;
-                    }
+        loop {
+            if let Some((i, leaf)) = &mut self.leaf {
+                if *i > 0 {
+                    *i -= 1;
+                    return leaf.keys.get(*i);
                 }
-                Node::Leaf(leaf) => {
-                    if *i > 0 {
-                        *i -= 1;
-                        return leaf.keys.get(*i);
-                    }
-                }
+                self.leaf = None;
+            }
+            let Some((i, branch)) = self.stack.last_mut() else {
+                break;
+            };
+            if *i > 0 {
+                *i -= 1;
+                let (i, branch) = (*i, *branch);
+                self.push_child(branch, i);
+                break;
             }
             self.stack.pop();
         }
@@ -962,7 +1284,7 @@ impl<'a, K, V, P: SharedPointerKind> Cursor<'a, K, V, P> {
     }
 
     pub(crate) fn peek(&self) -> Option<&'a (K, V)> {
-        if let Some((i, Node::Leaf(leaf))) = self.stack.last() {
+        if let Some((i, leaf)) = &self.leaf {
             leaf.keys.get(*i)
         } else {
             None


### PR DESCRIPTION
After #109, leaf and branch nodes have substantially different contents. This PR separates the `Node` enum into `Leaf` and `Branch` structs.
Inside the tree, each `Branch` then contains an enum `Children` that decides whether the next level is a layer of leaves or branches.

The main goal is to save a bit of memory in cases where Leaf and Branch structs would have very different sizes, since today's `Node` enum always takes as much space as the larger of the two.

This does make the code a bit more convoluted, especially `Cursor` which needs to differentiate between branch nodes and leaf nodes. Open to suggestions here if anyone has ideas to simplify things.

This appears to be a slight win on benchmarks too. Before:

```
test ordmap_insert_100         ... bench:      14,705.67 ns/iter (+/- 451.45)
test ordmap_insert_1000        ... bench:     259,427.08 ns/iter (+/- 6,744.83)
test ordmap_insert_mut_100     ... bench:       1,955.38 ns/iter (+/- 118.05)
test ordmap_insert_mut_1000    ... bench:      20,427.84 ns/iter (+/- 415.18)
test ordmap_insert_mut_10000   ... bench:     289,803.12 ns/iter (+/- 6,426.52)
test ordmap_insert_mut_100000  ... bench:   3,942,364.60 ns/iter (+/- 132,822.10)
test ordmap_insert_once_100    ... bench:         189.61 ns/iter (+/- 9.39)
test ordmap_insert_once_1000   ... bench:         309.52 ns/iter (+/- 14.42)
test ordmap_insert_once_10000  ... bench:         480.25 ns/iter (+/- 13.48)
test ordmap_iter_100           ... bench:         375.66 ns/iter (+/- 13.75)
test ordmap_iter_1000          ... bench:       3,479.75 ns/iter (+/- 44.62)
test ordmap_iter_10000         ... bench:      34,429.91 ns/iter (+/- 310.62)
test ordmap_lookup_100         ... bench:         806.07 ns/iter (+/- 38.87)
test ordmap_lookup_1000        ... bench:      11,746.56 ns/iter (+/- 165.48)
test ordmap_lookup_10000       ... bench:     218,264.60 ns/iter (+/- 3,321.23)
test ordmap_lookup_100000      ... bench:   3,295,079.20 ns/iter (+/- 166,419.53)
test ordmap_lookup_once_100    ... bench:           7.67 ns/iter (+/- 0.11)
test ordmap_lookup_once_1000   ... bench:          11.81 ns/iter (+/- 0.29)
test ordmap_lookup_once_10000  ... bench:          20.28 ns/iter (+/- 0.35)
test ordmap_lookup_once_100000 ... bench:          25.71 ns/iter (+/- 0.52)
test ordmap_range_iter_100     ... bench:         372.20 ns/iter (+/- 11.76)
test ordmap_range_iter_1000    ... bench:       3,469.57 ns/iter (+/- 27.77)
test ordmap_range_iter_10000   ... bench:      34,397.53 ns/iter (+/- 335.40)
test ordmap_range_iter_100000  ... bench:     343,621.90 ns/iter (+/- 5,937.52)
test ordmap_remove_100         ... bench:      14,068.70 ns/iter (+/- 384.53)
test ordmap_remove_1000        ... bench:     254,575.00 ns/iter (+/- 3,448.60)
test ordmap_remove_10000       ... bench:   4,453,150.00 ns/iter (+/- 118,543.81)
test ordmap_remove_max_1000    ... bench:     243,935.94 ns/iter (+/- 8,706.97)
test ordmap_remove_min_1000    ... bench:     239,202.77 ns/iter (+/- 4,434.34)
test ordmap_remove_mut_100     ... bench:       2,103.28 ns/iter (+/- 58.15)
test ordmap_remove_mut_1000    ... bench:      33,837.02 ns/iter (+/- 2,283.32)
test ordmap_remove_mut_10000   ... bench:     727,256.25 ns/iter (+/- 32,071.15)
test ordmap_remove_once_100    ... bench:         176.72 ns/iter (+/- 5.48)
test ordmap_remove_once_1000   ... bench:         291.31 ns/iter (+/- 8.27)
test ordmap_remove_once_10000  ... bench:         417.35 ns/iter (+/- 11.05)
test ordmap_remove_once_100000 ... bench:         594.49 ns/iter (+/- 23.42)
```

and after:

```
test ordmap_insert_100         ... bench:      12,012.98 ns/iter (+/- 320.34)
test ordmap_insert_1000        ... bench:     224,396.88 ns/iter (+/- 6,499.58)
test ordmap_insert_mut_100     ... bench:       1,536.60 ns/iter (+/- 34.81)
test ordmap_insert_mut_1000    ... bench:      20,096.69 ns/iter (+/- 805.69)
test ordmap_insert_mut_10000   ... bench:     298,062.24 ns/iter (+/- 6,894.25)
test ordmap_insert_mut_100000  ... bench:   3,983,441.70 ns/iter (+/- 109,447.91)
test ordmap_insert_once_100    ... bench:         161.52 ns/iter (+/- 10.82)
test ordmap_insert_once_1000   ... bench:         285.35 ns/iter (+/- 25.46)
test ordmap_insert_once_10000  ... bench:         453.71 ns/iter (+/- 13.95)
test ordmap_iter_100           ... bench:         281.34 ns/iter (+/- 5.14)
test ordmap_iter_1000          ... bench:       2,511.96 ns/iter (+/- 51.42)
test ordmap_iter_10000         ... bench:      24,757.92 ns/iter (+/- 661.44)
test ordmap_lookup_100         ... bench:         850.34 ns/iter (+/- 43.11)
test ordmap_lookup_1000        ... bench:      11,572.89 ns/iter (+/- 184.10)
test ordmap_lookup_10000       ... bench:     214,818.75 ns/iter (+/- 1,600.20)
test ordmap_lookup_100000      ... bench:   3,246,831.25 ns/iter (+/- 226,581.85)
test ordmap_lookup_once_100    ... bench:           7.51 ns/iter (+/- 0.24)
test ordmap_lookup_once_1000   ... bench:          11.72 ns/iter (+/- 0.24)
test ordmap_lookup_once_10000  ... bench:          20.23 ns/iter (+/- 0.37)
test ordmap_lookup_once_100000 ... bench:          25.76 ns/iter (+/- 0.95)
test ordmap_range_iter_100     ... bench:         281.13 ns/iter (+/- 4.83)
test ordmap_range_iter_1000    ... bench:       2,510.54 ns/iter (+/- 65.83)
test ordmap_range_iter_10000   ... bench:      24,760.22 ns/iter (+/- 337.61)
test ordmap_range_iter_100000  ... bench:     247,212.47 ns/iter (+/- 4,834.94)
test ordmap_remove_100         ... bench:      12,275.99 ns/iter (+/- 339.79)
test ordmap_remove_1000        ... bench:     237,194.80 ns/iter (+/- 4,486.99)
test ordmap_remove_10000       ... bench:   4,242,789.60 ns/iter (+/- 94,905.61)
test ordmap_remove_max_1000    ... bench:     223,509.11 ns/iter (+/- 6,618.93)
test ordmap_remove_min_1000    ... bench:     223,864.84 ns/iter (+/- 4,699.89)
test ordmap_remove_mut_100     ... bench:       2,198.51 ns/iter (+/- 30.21)
test ordmap_remove_mut_1000    ... bench:      36,564.62 ns/iter (+/- 2,202.62)
test ordmap_remove_mut_10000   ... bench:     727,337.40 ns/iter (+/- 31,648.61)
test ordmap_remove_once_100    ... bench:         157.04 ns/iter (+/- 4.32)
test ordmap_remove_once_1000   ... bench:         287.27 ns/iter (+/- 17.54)
test ordmap_remove_once_10000  ... bench:         387.15 ns/iter (+/- 38.51)
test ordmap_remove_once_100000 ... bench:         565.89 ns/iter (+/- 36.19)
```

(measured on an M1 Mac)