### PR TITLE
Revert "fix lifetimes for ordmap"

### DIFF
--- a/src/nodes/btree.rs
+++ b/src/nodes/btree.rs
@@ -648,7 +648,7 @@ impl<K: Ord + Clone, V: Clone> Leaf<K, V> {
 }
 
 impl<K: Ord + Clone, V: Clone, P: SharedPointerKind> Node<K, V, P> {
-    pub(crate) fn lookup_mut<'a, BK>(&'a mut self, key: &BK) -> Option<(&'a K, &'a mut V)>
+    pub(crate) fn lookup_mut<BK>(&mut self, key: &BK) -> Option<(&K, &mut V)>
     where
         BK: Ord + ?Sized,
         K: Borrow<BK>,

--- a/src/ord/map.rs
+++ b/src/ord/map.rs
@@ -571,7 +571,7 @@ where
     /// );
     /// ```
     #[must_use]
-    pub fn get_mut<'a, BK>(&'a mut self, key: &BK) -> Option<&'a mut V>
+    pub fn get_mut<BK>(&mut self, key: &BK) -> Option<&mut V>
     where
         BK: Ord + ?Sized,
         K: Borrow<BK>,
@@ -596,7 +596,7 @@ where
     /// );
     /// ```
     #[must_use]
-    pub fn get_key_value_mut<'a, BK>(&'a mut self, key: &BK) -> Option<(&'a K, &'a mut V)>
+    pub fn get_key_value_mut<BK>(&mut self, key: &BK) -> Option<(&K, &mut V)>
     where
         BK: Ord + ?Sized,
         K: Borrow<BK>,
@@ -624,7 +624,7 @@ where
     /// assert_eq!(ordmap![1 => 1, 3 => 4, 5 => 5], map);
     /// ```
     #[must_use]
-    pub fn get_prev_mut<'a, BK>(&'a mut self, key: &BK) -> Option<(&'a K, &'a mut V)>
+    pub fn get_prev_mut<BK>(&mut self, key: &BK) -> Option<(&K, &mut V)>
     where
         BK: Ord + ?Sized,
         K: Borrow<BK>,
@@ -654,7 +654,7 @@ where
     /// assert_eq!(ordmap![1 => 1, 3 => 3, 5 => 4], map);
     /// ```
     #[must_use]
-    pub fn get_next_mut<'a, BK>(&'a mut self, key: &BK) -> Option<(&'a K, &'a mut V)>
+    pub fn get_next_mut<BK>(&mut self, key: &BK) -> Option<(&K, &mut V)>
     where
         BK: Ord + ?Sized,
         K: Borrow<BK>,


### PR DESCRIPTION
Reverts jneem/imbl#119 because it was a no-op and the original version of the code was easier to read.
If you run clippy on the current codebase, I would expect it to also point this out.