### PR TITLE
Optimize HAMT HashMap with linear probing and small nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Lower HashMap and HashSet memory usage (#129)
+- Optimize HashMap and HashSet iteration speed (#129)
 - Fix `vector::Iter` is not `Clone` when `triomphe` is enabled (#107)
 
 ### Changed
@@ -24,7 +26,7 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
- - Support different pointer types (thanks @inker0!) (#90). This is technically a breaking
+- Support different pointer types (thanks @inker0!) (#90). This is technically a breaking
    change since some types (like iterators) grew additional generic parameters.
 
 ### Fixed

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,9 +9,9 @@ pub(crate) const VECTOR_CHUNK_SIZE: usize = 4;
 pub(crate) const VECTOR_CHUNK_SIZE: usize = 64;
 
 /// The branching factor of B-trees
-// Must be an even number!
-// Value if 6 chosen improve test coverage, specifically
+// Value of 6 chosen improve test coverage, specifically
 // so that both deletion node merging and rebalancing are tested.
+// Must be an even number!
 #[cfg(feature = "small-chunks")]
 pub(crate) const ORD_CHUNK_SIZE: usize = 6;
 #[cfg(not(feature = "small-chunks"))]
@@ -19,7 +19,9 @@ pub(crate) const ORD_CHUNK_SIZE: usize = 64;
 
 /// The level size of HAMTs, in bits
 /// Branching factor is 2 ^ HashLevelSize.
+// The smallest supported value is 3 currently, as the small node
+// (half the size of a full node) requires at least 4 slots.
 #[cfg(feature = "small-chunks")]
-pub(crate) const HASH_LEVEL_SIZE: usize = 2;
+pub(crate) const HASH_LEVEL_SIZE: usize = 3;
 #[cfg(not(feature = "small-chunks"))]
 pub(crate) const HASH_LEVEL_SIZE: usize = 5;

--- a/src/hash/map.rs
+++ b/src/hash/map.rs
@@ -2548,25 +2548,25 @@ mod test {
             }
         }
     }
-}
 
-#[test]
-fn test_structure_summary() {
-    // Test with different sizes of HashMaps
-    let sizes = vec![10, 100, 1_000, 10_000, 100_000];
+    #[test]
+    fn test_structure_summary() {
+        // Test with different sizes of HashMaps
+        let sizes = vec![10, 100, 1_000, 10_000, 100_000];
 
-    for size in sizes {
-        println!("\n=== Testing with {} entries ===", size);
+        for size in sizes {
+            println!("\n=== Testing with {} entries ===", size);
 
-        let mut map = HashMap::new();
+            let mut map = HashMap::new();
 
-        // Insert entries
-        for i in 0..size {
-            // dbg!(i);
-            map.insert(i, i * 2);
+            // Insert entries
+            for i in 0..size {
+                // dbg!(i);
+                map.insert(i, i * 2);
+            }
+
+            // Print structure summary
+            map.print_structure_summary();
         }
-
-        // Print structure summary
-        map.print_structure_summary();
     }
 }

--- a/src/nodes/hamt.rs
+++ b/src/nodes/hamt.rs
@@ -16,24 +16,17 @@ use bitmaps::{Bits, BitsImpl};
 use imbl_sized_chunks::inline_array::InlineArray;
 use imbl_sized_chunks::sparse_chunk::{Iter as ChunkIter, IterMut as ChunkIterMut, SparseChunk};
 
-use crate::util::clone_ref;
-
 use crate::config::HASH_LEVEL_SIZE as HASH_SHIFT;
 pub(crate) type HashBits = <BitsImpl<HASH_WIDTH> as Bits>::Store; // a uint of HASH_WIDTH bits
 
 const HASH_WIDTH: usize = 2_usize.pow(HASH_SHIFT as u32);
-const HASH_MASK: HashBits = (HASH_WIDTH - 1) as HashBits;
-const ITER_STACK_CAPACITY: usize = (HASH_WIDTH / HASH_SHIFT) + 1;
+const ITER_STACK_CAPACITY: usize = HASH_WIDTH.div_ceil(HASH_SHIFT) + 1;
+const SMALL_NODE_WIDTH: usize = HASH_WIDTH / 2;
 
 pub(crate) fn hash_key<K: Hash + ?Sized, S: BuildHasher>(bh: &S, key: &K) -> HashBits {
     let mut hasher = bh.build_hasher();
     key.hash(&mut hasher);
     hasher.finish() as HashBits
-}
-
-#[inline]
-fn mask(hash: HashBits, shift: usize) -> HashBits {
-    hash >> shift & HASH_MASK
 }
 
 pub trait HashValue {
@@ -43,15 +36,460 @@ pub trait HashValue {
     fn ptr_eq(&self, other: &Self) -> bool;
 }
 
-pub(crate) struct Node<A, P: SharedPointerKind> {
-    data: SparseChunk<Entry<A, P>, HASH_WIDTH>,
+pub(crate) struct GenericNode<A, P: SharedPointerKind, const WIDTH: usize>
+where
+    BitsImpl<WIDTH>: Bits,
+{
+    /// Whether this node is using linear probing for collision resolution.
+    /// When true all child nodes are `Value`s.
+    /// Default for a new node is true.
+    linear_probing: bool,
+    /// Nodes with  `WIDTH` < `HASH_WIDTH` are used for small nodes.
+    /// Small only contains `Value`s, and are always linear probing.
+    ///
+    /// Note that using SparseChunk<(A, HashBits), WIDTH> for small nodes wouldn't yield
+    /// memory savings in most cases the padding space allows the enum
+    /// Entry to be stored in the same space. So we use
+    /// SparseChunk<Entry<A, P>, WIDTH> instead to increase code reuse.
+    data: SparseChunk<Entry<A, P>, WIDTH>,
 }
 
-impl<A: Clone, P: SharedPointerKind> Clone for Node<A, P> {
+impl<A: Clone, P: SharedPointerKind, const WIDTH: usize> Clone for GenericNode<A, P, WIDTH>
+where
+    BitsImpl<WIDTH>: Bits,
+{
     fn clone(&self) -> Self {
         Self {
+            linear_probing: self.linear_probing,
             data: self.data.clone(),
         }
+    }
+}
+
+pub(crate) type Node<A, P> = GenericNode<A, P, HASH_WIDTH>;
+pub(crate) type SmallNode<A, P> = GenericNode<A, P, SMALL_NODE_WIDTH>;
+
+impl<A, P: SharedPointerKind, const WIDTH: usize> Default for GenericNode<A, P, WIDTH>
+where
+    BitsImpl<WIDTH>: Bits,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<A, P: SharedPointerKind, const WIDTH: usize> GenericNode<A, P, WIDTH>
+where
+    BitsImpl<WIDTH>: Bits,
+{
+    #[inline(always)]
+    pub(crate) fn new() -> Self {
+        GenericNode {
+            linear_probing: true,
+            data: SparseChunk::new(),
+        }
+    }
+
+    #[inline]
+    fn with(with: impl FnOnce(&mut Self)) -> SharedPointer<Self, P> {
+        let result: SharedPointer<UnsafeCell<mem::MaybeUninit<Self>>, P> =
+            SharedPointer::new(UnsafeCell::new(mem::MaybeUninit::uninit()));
+        #[allow(unsafe_code)]
+        unsafe {
+            (&mut *result.get()).write(Self::new());
+            let mut_ptr = &mut *UnsafeCell::raw_get(&*result);
+            let mut_ptr = MaybeUninit::as_mut_ptr(mut_ptr);
+            with(&mut *mut_ptr);
+            let result = ManuallyDrop::new(result);
+            mem::transmute_copy(&result)
+        }
+    }
+
+    #[inline]
+    pub(crate) fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    #[inline]
+    fn mask(hash: HashBits, shift: usize) -> HashBits {
+        let mask = (WIDTH - 1) as HashBits;
+        hash >> shift & mask
+    }
+
+    fn pop(&mut self) -> Entry<A, P> {
+        self.data.pop().unwrap()
+    }
+}
+
+impl<A: HashValue, P: SharedPointerKind, const WIDTH: usize> GenericNode<A, P, WIDTH>
+where
+    BitsImpl<WIDTH>: Bits,
+{
+    pub(crate) fn get<BK>(&self, hash: HashBits, shift: usize, key: &BK) -> Option<&A>
+    where
+        BK: Eq + ?Sized,
+        A::Key: Borrow<BK>,
+    {
+        let mut index = Self::mask(hash, shift) as usize;
+        while let Some(entry) = self.data.get(index) {
+            return match entry {
+                Entry::Value(ref value, value_hash) => {
+                    if hash_may_eq::<A>(hash, *value_hash) && key == value.extract_key().borrow() {
+                        Some(value)
+                    } else if !self.linear_probing {
+                        None
+                    } else {
+                        index = (index + 1) % WIDTH;
+                        continue;
+                    }
+                }
+                Entry::Node(ref child) => {
+                    assert_eq!(
+                        WIDTH, HASH_WIDTH,
+                        "SmallNode should not contain Node entries"
+                    );
+                    child.get(hash, shift + HASH_SHIFT, key)
+                }
+                Entry::SmallNode(ref small) => {
+                    assert_eq!(
+                        WIDTH, HASH_WIDTH,
+                        "SmallNode should not contain SmallNode entries"
+                    );
+                    small.get(hash, shift + HASH_SHIFT, key)
+                }
+                Entry::Collision(ref coll) => coll.get(key),
+            };
+        }
+        None
+    }
+
+    pub(crate) fn get_mut<BK>(&mut self, hash: HashBits, shift: usize, key: &BK) -> Option<&mut A>
+    where
+        A: Clone,
+        BK: Eq + ?Sized,
+        A::Key: Borrow<BK>,
+    {
+        let this = self as *mut Self;
+        #[allow(dropping_references)]
+        drop(self); // prevent self from being used or moved, so it's is safe to dereference `this` later
+        let mut index = Self::mask(hash, shift) as usize;
+        loop {
+            // Restore a mutable reference to self to avoid hitting the borrow checker
+            // limitation that prevents us from returning mutable references from the original
+            // `self` inside a loop. This is safe because we only restore the mutable reference
+            // once per iteration and the references goes out of scope at the end of the loop.
+            #[allow(unsafe_code)]
+            let this = unsafe { &mut *this };
+            return match this.data.get_mut(index) {
+                Some(Entry::Value(ref mut value, value_hash)) => {
+                    if hash_may_eq::<A>(hash, *value_hash) && key == value.extract_key().borrow() {
+                        Some(value)
+                    } else if !this.linear_probing {
+                        None
+                    } else {
+                        index = (index + 1) % WIDTH;
+                        continue;
+                    }
+                }
+                Some(Entry::Node(ref mut child_ref)) => {
+                    assert_eq!(
+                        WIDTH, HASH_WIDTH,
+                        "SmallNode should not contain Node entries"
+                    );
+                    SharedPointer::make_mut(child_ref).get_mut(hash, shift + HASH_SHIFT, key)
+                }
+                Some(Entry::SmallNode(ref mut small_ref)) => {
+                    assert_eq!(
+                        WIDTH, HASH_WIDTH,
+                        "SmallNode should not contain SmallNode entries"
+                    );
+                    SharedPointer::make_mut(small_ref).get_mut(hash, shift + HASH_SHIFT, key)
+                }
+                Some(Entry::Collision(ref mut coll_ref)) => {
+                    SharedPointer::make_mut(coll_ref).get_mut(key)
+                }
+                None => None,
+            };
+        }
+    }
+
+    /// Perform backwards shift if using linear probing or attempt to restore linear probing
+    #[inline]
+    fn adjust_post_removal(&mut self, shift: usize, mut index: usize) {
+        if self.linear_probing {
+            let mut next = (index + 1) % WIDTH;
+            while let Some(Entry::Value(_, value_hash)) = self.data.get(next) {
+                let ideal_index = Self::mask(*value_hash, shift) as usize;
+                let next_dib = next.wrapping_sub(ideal_index) % WIDTH;
+                let index_dib = index.wrapping_sub(ideal_index) % WIDTH;
+                if index_dib < next_dib {
+                    let entry = self.data.remove(next).unwrap();
+                    self.data.insert(index, entry);
+                    index = next;
+                }
+                next = (next + 1) % WIDTH;
+            }
+        } else {
+            // If we ended up with a single value, restore linear probing
+            if self.data.len() == 1 && self.data.iter().next().is_some_and(|e| e.is_value()) {
+                self.linear_probing = true;
+            }
+        }
+    }
+}
+
+// Separate implementation block for SmallNode-specific method
+impl<A: HashValue, P: SharedPointerKind> SmallNode<A, P> {
+    pub(crate) fn insert(&mut self, hash: HashBits, shift: usize, value: A) -> Result<Option<A>, A>
+    where
+        A: Clone,
+    {
+        let mut index = Self::mask(hash, shift) as usize;
+        while let Some(entry) = self.data.get_mut(index) {
+            match entry {
+                Entry::Value(ref mut existing, existing_hash) => {
+                    if hash_may_eq::<A>(hash, *existing_hash)
+                        && existing.extract_key() == value.extract_key()
+                    {
+                        return Ok(Some(mem::replace(existing, value)));
+                    }
+                    if self.linear_probing {
+                        index = (index + 1) % SMALL_NODE_WIDTH;
+                        continue;
+                    } else {
+                        return Err(value);
+                    }
+                }
+                _ => unreachable!("SmallNode should only contain Values"),
+            }
+        }
+
+        // Check if we need to disable linear probing
+        if self.linear_probing && self.data.len() >= SMALL_NODE_WIDTH / 2 {
+            // Need to upgrade to Node
+            return Err(value);
+        }
+
+        self.data.insert(index, Entry::Value(value, hash));
+        Ok(None)
+    }
+
+    pub(crate) fn remove<BK>(&mut self, hash: HashBits, shift: usize, key: &BK) -> Option<A>
+    where
+        A: Clone,
+        BK: Eq + ?Sized,
+        A::Key: Borrow<BK>,
+    {
+        let mut index = Self::mask(hash, shift) as usize;
+        loop {
+            match self.data.get(index) {
+                None => return None,
+                Some(Entry::Value(value, value_hash)) => {
+                    if hash_may_eq::<A>(hash, *value_hash) && key == value.extract_key().borrow() {
+                        break;
+                    } else if !self.linear_probing {
+                        return None;
+                    } else {
+                        index = (index + 1) % SMALL_NODE_WIDTH;
+                    }
+                }
+                _ => unreachable!("SmallNode should only contain Values"),
+            }
+        }
+
+        let removed = self.data.remove(index).map(Entry::unwrap_value);
+        self.adjust_post_removal(shift, index);
+        removed
+    }
+}
+
+// Implementation block for Node-specific methods
+impl<A: HashValue, P: SharedPointerKind> Node<A, P> {
+    #[inline]
+    fn merge_values(
+        value1: A,
+        hash1: HashBits,
+        value2: A,
+        hash2: HashBits,
+        shift: usize,
+    ) -> Entry<A, P> {
+        let small_index1 = SmallNode::<A, P>::mask(hash1, shift) as usize;
+        let mut small_index2 = SmallNode::<A, P>::mask(hash2, shift) as usize;
+        if small_index1 == small_index2 {
+            small_index2 = (small_index1 + 1) % SMALL_NODE_WIDTH;
+        }
+        let small_node = SmallNode::with(|node| {
+            node.data.insert(small_index1, Entry::Value(value1, hash1));
+            node.data.insert(small_index2, Entry::Value(value2, hash2));
+        });
+        Entry::SmallNode(small_node)
+    }
+
+    #[allow(unsafe_code)]
+    pub(crate) fn insert(&mut self, hash: HashBits, shift: usize, value: A) -> Option<A>
+    where
+        A: Clone,
+    {
+        let mut index = Self::mask(hash, shift) as usize;
+        while let Some(entry) = self.data.get_mut(index) {
+            // Value is here
+            match entry {
+                // Update value or create a subtree
+                Entry::Value(ref mut current, current_hash) => {
+                    if hash_may_eq::<A>(hash, *current_hash)
+                        && current.extract_key() == value.extract_key()
+                    {
+                        return Some(mem::replace(current, value));
+                    }
+                    if self.linear_probing {
+                        index = (index + 1) % HASH_WIDTH;
+                        continue;
+                    }
+                }
+                Entry::Node(ref mut child_ref) => {
+                    let child = SharedPointer::make_mut(child_ref);
+                    return child.insert(hash, shift + HASH_SHIFT, value);
+                }
+                Entry::SmallNode(ref mut small_ref) => {
+                    let small = SharedPointer::make_mut(small_ref);
+                    match small.insert(hash, shift + HASH_SHIFT, value) {
+                        Ok(result) => return result,
+                        Err(value) => {
+                            // It's a collision, need to upgrade to Node
+                            let mut node = Node::new();
+                            for entry in mem::take(&mut small.data) {
+                                if let Entry::Value(v, h) = entry {
+                                    node.insert(h, shift + HASH_SHIFT, v);
+                                } else {
+                                    unreachable!("SmallNode should only contain Values");
+                                }
+                            }
+
+                            // Insert the new value
+                            node.insert(hash, shift + HASH_SHIFT, value);
+                            *entry = Entry::Node(SharedPointer::new(node));
+                            return None;
+                        }
+                    }
+                }
+                // There's already a collision here.
+                Entry::Collision(ref mut collision) => {
+                    let coll = SharedPointer::make_mut(collision);
+                    return coll.insert(value);
+                }
+            }
+
+            // If we get here, we're inserting a value over an exiting value (collision).
+            // We're going to be unsafe and pry it out of the reference, trusting
+            // that we overwrite it with the merged node.
+            let Entry::Value(old_value, old_hash) = (unsafe { ptr::read(entry) }) else {
+                unreachable!()
+            };
+            let new_entry = if shift + HASH_SHIFT >= HASH_WIDTH {
+                // We're at the lowest level, need to set up a collision node.
+                let coll = CollisionNode::new(hash, old_value, value);
+                Entry::from(coll)
+            } else {
+                Node::merge_values(old_value, old_hash, value, hash, shift + HASH_SHIFT)
+            };
+            unsafe { ptr::write(entry, new_entry) };
+            return None;
+        }
+
+        if self.linear_probing && self.data.len() >= HASH_WIDTH / 2 {
+            self.linear_probing = false;
+            for entry in mem::take(&mut self.data) {
+                if let Entry::Value(value, hash) = entry {
+                    self.insert(hash, shift, value);
+                } else {
+                    unreachable!("linear probing nodes should only contain values")
+                }
+            }
+            return self.insert(hash, shift, value);
+        }
+        self.data.insert(index, Entry::Value(value, hash));
+        None
+    }
+
+    pub(crate) fn remove<BK>(&mut self, hash: HashBits, shift: usize, key: &BK) -> Option<A>
+    where
+        A: Clone,
+        BK: Eq + ?Sized,
+        A::Key: Borrow<BK>,
+    {
+        let mut index = Self::mask(hash, shift) as usize;
+        // First find the entry to remove
+        loop {
+            match self.data.get(index) {
+                None => return None,
+                Some(Entry::Value(value, value_hash)) => {
+                    if hash_may_eq::<A>(hash, *value_hash) && key == value.extract_key().borrow() {
+                        break;
+                    } else if !self.linear_probing {
+                        return None;
+                    } else {
+                        index = (index + 1) % HASH_WIDTH;
+                    }
+                }
+                Some(Entry::Collision(_) | Entry::Node(_) | Entry::SmallNode(_)) => break,
+            }
+        }
+
+        let new_node;
+        let removed;
+        match self.data.get_mut(index).unwrap() {
+            Entry::Node(ref mut child_ref) => {
+                let child = SharedPointer::make_mut(child_ref);
+                match child.remove(hash, shift + HASH_SHIFT, key) {
+                    None => return None,
+                    Some(value) => {
+                        if child.len() == 1
+                            && child.data.iter().next().is_some_and(|e| e.is_value())
+                        {
+                            removed = Some(value);
+                            new_node = Some(child.pop());
+                        } else {
+                            return Some(value);
+                        }
+                    }
+                }
+            }
+            Entry::SmallNode(ref mut small_ref) => {
+                let small = SharedPointer::make_mut(small_ref);
+                match small.remove(hash, shift + HASH_SHIFT, key) {
+                    None => return None,
+                    Some(value) => {
+                        if small.len() == 1 {
+                            removed = Some(value);
+                            new_node = Some(small.pop());
+                        } else {
+                            return Some(value);
+                        }
+                    }
+                }
+            }
+            Entry::Value(..) => {
+                new_node = None;
+                removed = self.data.remove(index).map(Entry::unwrap_value);
+            }
+            Entry::Collision(ref mut coll_ref) => {
+                let coll = SharedPointer::make_mut(coll_ref);
+                removed = coll.remove(key);
+                if coll.len() == 1 {
+                    new_node = Some(coll.pop());
+                } else {
+                    return removed;
+                }
+            }
+        }
+
+        if let Some(node) = new_node {
+            self.data.insert(index, node);
+        } else {
+            self.adjust_post_removal(shift, index);
+        }
+
+        removed
     }
 }
 
@@ -65,6 +503,7 @@ pub(crate) enum Entry<A, P: SharedPointerKind> {
     Value(A, HashBits),
     Collision(SharedPointer<CollisionNode<A>, P>),
     Node(SharedPointer<Node<A, P>, P>),
+    SmallNode(SharedPointer<SmallNode<A, P>, P>),
 }
 
 impl<A: Clone, P: SharedPointerKind> Clone for Entry<A, P> {
@@ -73,6 +512,7 @@ impl<A: Clone, P: SharedPointerKind> Clone for Entry<A, P> {
             Entry::Value(value, hash) => Entry::Value(value.clone(), *hash),
             Entry::Collision(coll) => Entry::Collision(coll.clone()),
             Entry::Node(node) => Entry::Node(node.clone()),
+            Entry::SmallNode(node) => Entry::SmallNode(node.clone()),
         }
     }
 }
@@ -96,277 +536,11 @@ impl<A, P: SharedPointerKind> From<CollisionNode<A>> for Entry<A, P> {
     }
 }
 
-impl<A, P: SharedPointerKind> Default for Node<A, P> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<A, P: SharedPointerKind> Node<A, P> {
-    #[inline(always)]
-    pub(crate) fn new() -> Self {
-        Node {
-            data: SparseChunk::new(),
-        }
-    }
-
-    /// Special constructor to allow initializing Nodes w/o incurring multiple memory copies.
-    /// These copies really slow things down once Node crosses a certain size threshold and copies become calls to memcopy.
-    #[inline]
-    fn with(with: impl FnOnce(&mut Self)) -> SharedPointer<Self, P> {
-        let result: SharedPointer<UnsafeCell<mem::MaybeUninit<Self>>, P> =
-            SharedPointer::new(UnsafeCell::new(mem::MaybeUninit::uninit()));
-        #[allow(unsafe_code)]
-        unsafe {
-            // Initialize the MaybeUninit node
-            (&mut *result.get()).write(Node::new());
-            // Dereference all the way to the newly initialized &mut Node
-            let mut_ptr = &mut *UnsafeCell::raw_get(&*result);
-            let mut_ptr = MaybeUninit::as_mut_ptr(mut_ptr);
-            with(&mut *mut_ptr);
-            // Note that transmute isn't usable with the generic argument P, so we have to use
-            // a combination of transmute_copy and ManuallyDrop
-            // Safety: UnsafeCell<_> and UnsafeCell<MaybeUninit<_>> have the same memory representation
-            //         and ManuallyDrop<T> and T have the same memory representation
-            let result = ManuallyDrop::new(result);
-            mem::transmute_copy(&result)
-        }
-    }
-
-    #[inline]
-    fn len(&self) -> usize {
-        self.data.len()
-    }
-
-    #[inline]
-    fn unit(index: usize, value: Entry<A, P>) -> SharedPointer<Self, P> {
-        Self::with(|this| {
-            this.data.insert(index, value);
-        })
-    }
-
-    #[inline]
-    fn pair(
-        index1: usize,
-        value1: Entry<A, P>,
-        index2: usize,
-        value2: Entry<A, P>,
-    ) -> SharedPointer<Self, P> {
-        Self::with(|this| {
-            this.data.insert(index1, value1);
-            this.data.insert(index2, value2);
-        })
-    }
-
-    #[inline]
-    pub(crate) fn single_child(
-        index: usize,
-        node: SharedPointer<Self, P>,
-    ) -> SharedPointer<Self, P> {
-        Self::unit(index, Entry::Node(node))
-    }
-
-    fn pop(&mut self) -> Entry<A, P> {
-        self.data.pop().unwrap()
-    }
-}
-
-impl<A: HashValue, P: SharedPointerKind> Node<A, P> {
-    fn merge_values(
-        value1: A,
-        hash1: HashBits,
-        value2: A,
-        hash2: HashBits,
-        shift: usize,
-    ) -> SharedPointer<Self, P> {
-        let index1 = mask(hash1, shift) as usize;
-        let index2 = mask(hash2, shift) as usize;
-        if index1 != index2 {
-            // Both values fit on the same level.
-            Node::pair(
-                index1,
-                Entry::Value(value1, hash1),
-                index2,
-                Entry::Value(value2, hash2),
-            )
-        } else if shift + HASH_SHIFT >= HASH_WIDTH {
-            // If we're at the bottom, we've got a collision.
-            Node::unit(
-                index1,
-                Entry::from(CollisionNode::new(hash1, value1, value2)),
-            )
-        } else {
-            // Pass the values down a level.
-            let node = Node::merge_values(value1, hash1, value2, hash2, shift + HASH_SHIFT);
-            Node::single_child(index1, node)
-        }
-    }
-
-    pub(crate) fn get<BK>(&self, hash: HashBits, shift: usize, key: &BK) -> Option<&A>
-    where
-        BK: Eq + ?Sized,
-        A::Key: Borrow<BK>,
-    {
-        let index = mask(hash, shift) as usize;
-        if let Some(entry) = self.data.get(index) {
-            match entry {
-                Entry::Value(ref value, _) => {
-                    if key == value.extract_key().borrow() {
-                        Some(value)
-                    } else {
-                        None
-                    }
-                }
-                Entry::Collision(ref coll) => coll.get(key),
-                Entry::Node(ref child) => child.get(hash, shift + HASH_SHIFT, key),
-            }
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn get_mut<BK>(&mut self, hash: HashBits, shift: usize, key: &BK) -> Option<&mut A>
-    where
-        A: Clone,
-        BK: Eq + ?Sized,
-        A::Key: Borrow<BK>,
-    {
-        let index = mask(hash, shift) as usize;
-        if let Some(entry) = self.data.get_mut(index) {
-            match entry {
-                Entry::Value(ref mut value, _) => {
-                    if key == value.extract_key().borrow() {
-                        Some(value)
-                    } else {
-                        None
-                    }
-                }
-                Entry::Collision(ref mut coll_ref) => {
-                    let coll = SharedPointer::make_mut(coll_ref);
-                    coll.get_mut(key)
-                }
-                Entry::Node(ref mut child_ref) => {
-                    let child = SharedPointer::make_mut(child_ref);
-                    child.get_mut(hash, shift + HASH_SHIFT, key)
-                }
-            }
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn insert(&mut self, hash: HashBits, shift: usize, value: A) -> Option<A>
-    where
-        A: Clone,
-    {
-        let index = mask(hash, shift) as usize;
-        if let Some(entry) = self.data.get_mut(index) {
-            let mut fallthrough = false;
-            // Value is here
-            match entry {
-                // Update value or create a subtree
-                Entry::Value(ref current, _) => {
-                    if current.extract_key() == value.extract_key() {
-                        // If we have a key match, fall through to the outer
-                        // level where we replace the current value. If we
-                        // don't, fall through to the inner level where we merge
-                        // some nodes.
-                        fallthrough = true;
-                    }
-                }
-                // There's already a collision here.
-                Entry::Collision(ref mut collision) => {
-                    let coll = SharedPointer::make_mut(collision);
-                    return coll.insert(value);
-                }
-                Entry::Node(ref mut child_ref) => {
-                    // Child node
-                    let child = SharedPointer::make_mut(child_ref);
-                    return child.insert(hash, shift + HASH_SHIFT, value);
-                }
-            }
-            #[allow(unsafe_code)]
-            if !fallthrough {
-                // If we get here, we're looking at a value entry that needs a merge.
-                // We're going to be unsafe and pry it out of the reference, trusting
-                // that we overwrite it with the merged node.
-                let old_entry = unsafe { ptr::read(entry) };
-                if shift + HASH_SHIFT >= HASH_WIDTH {
-                    // We're at the lowest level, need to set up a collision node.
-                    let coll = CollisionNode::new(hash, old_entry.unwrap_value(), value);
-                    unsafe { ptr::write(entry, Entry::from(coll)) };
-                } else if let Entry::Value(old_value, old_hash) = old_entry {
-                    let node =
-                        Node::merge_values(old_value, old_hash, value, hash, shift + HASH_SHIFT);
-                    unsafe { ptr::write(entry, Entry::Node(node)) };
-                } else {
-                    unreachable!()
-                }
-                return None;
-            }
-        }
-        // If we get here, either we found nothing at this index, in which case
-        // we insert a new entry, or we hit a value entry with the same key, in
-        // which case we replace it.
-        self.data
-            .insert(index, Entry::Value(value, hash))
-            .map(Entry::unwrap_value)
-    }
-
-    pub(crate) fn remove<BK>(&mut self, hash: HashBits, shift: usize, key: &BK) -> Option<A>
-    where
-        A: Clone,
-        BK: Eq + ?Sized,
-        A::Key: Borrow<BK>,
-    {
-        let index = mask(hash, shift) as usize;
-        let mut new_node = None;
-        let mut removed = None;
-        if let Some(entry) = self.data.get_mut(index) {
-            match entry {
-                Entry::Value(ref value, _) => {
-                    if key != value.extract_key().borrow() {
-                        // Key wasn't in the map.
-                        return None;
-                    } // Otherwise, fall through to the removal.
-                }
-                Entry::Collision(ref mut coll_ref) => {
-                    let coll = SharedPointer::make_mut(coll_ref);
-                    removed = coll.remove(key);
-                    if coll.len() == 1 {
-                        new_node = Some(coll.pop());
-                    } else {
-                        return removed;
-                    }
-                }
-                Entry::Node(ref mut child_ref) => {
-                    let child = SharedPointer::make_mut(child_ref);
-                    match child.remove(hash, shift + HASH_SHIFT, key) {
-                        None => {
-                            return None;
-                        }
-                        Some(value) => {
-                            if child.len() == 1
-                                && child.data[child.data.first_index().unwrap()].is_value()
-                            {
-                                // If the child now contains only a single value node,
-                                // pull it up one level and discard the child.
-                                removed = Some(value);
-                                new_node = Some(child.pop());
-                            } else {
-                                return Some(value);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        if let Some(node) = new_node {
-            self.data.insert(index, node);
-            return removed;
-        }
-        self.data.remove(index).map(Entry::unwrap_value)
-    }
+/// Compare two hashes, returning true if the keys may be equal.
+/// This function will always return true if it thinks keys may be cheap to compare.
+#[inline]
+fn hash_may_eq<A: HashValue>(hash: HashBits, other_hash: HashBits) -> bool {
+    (!mem::needs_drop::<A::Key>() && mem::size_of::<A::Key>() <= 16) || hash == other_hash
 }
 
 impl<A: HashValue> CollisionNode<A> {
@@ -378,7 +552,7 @@ impl<A: HashValue> CollisionNode<A> {
     }
 
     #[inline]
-    fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.data.len()
     }
 
@@ -435,14 +609,43 @@ impl<A: HashValue> CollisionNode<A> {
     }
 }
 
+#[cfg(test)]
+impl<A, P: SharedPointerKind> Node<A, P> {
+    /// Analyze the node structure for debugging/statistics
+    pub(crate) fn analyze_structure<F>(&self, mut visitor: F)
+    where
+        F: FnMut(&Entry<A, P>),
+    {
+        for i in self.data.indices() {
+            visitor(&self.data[i]);
+        }
+    }
+}
+
 /// An allocation-free stack for iterators.
 type InlineStack<T> = InlineArray<T, (usize, [T; ITER_STACK_CAPACITY])>;
+
+enum IterItem<'a, A, P: SharedPointerKind> {
+    Node(ChunkIter<'a, Entry<A, P>, HASH_WIDTH>),
+    SmallNode(ChunkIter<'a, Entry<A, P>, SMALL_NODE_WIDTH>),
+}
+
+// We manually impl Clone for IterItem to allow cloning even when A isn't Clone
+// This works because the iterators hold references, not owned values
+impl<'a, A, P: SharedPointerKind> Clone for IterItem<'a, A, P> {
+    fn clone(&self) -> Self {
+        match self {
+            IterItem::Node(iter) => IterItem::Node(iter.clone()),
+            IterItem::SmallNode(iter) => IterItem::SmallNode(iter.clone()),
+        }
+    }
+}
 
 // Ref iterator
 
 pub(crate) struct Iter<'a, A, P: SharedPointerKind> {
     count: usize,
-    stack: InlineStack<ChunkIter<'a, Entry<A, P>, HASH_WIDTH>>,
+    stack: InlineStack<IterItem<'a, A, P>>,
     collision: Option<(HashBits, SliceIter<'a, A>)>,
 }
 
@@ -469,7 +672,7 @@ where
             collision: None,
         };
         if let Some(node) = root {
-            result.stack.push(node.data.iter());
+            result.stack.push(IterItem::Node(node.data.iter()));
         }
         result
     }
@@ -495,13 +698,20 @@ where
             }
 
             while let Some(current) = self.stack.last_mut() {
-                match current.next() {
+                let next_entry = match current {
+                    IterItem::Node(iter) => iter.next(),
+                    IterItem::SmallNode(iter) => iter.next(),
+                };
+                match next_entry {
                     Some(Entry::Value(value, hash)) => {
                         self.count -= 1;
                         return Some((value, *hash));
                     }
                     Some(Entry::Node(child)) => {
-                        self.stack.push(child.data.iter());
+                        self.stack.push(IterItem::Node(child.data.iter()));
+                    }
+                    Some(Entry::SmallNode(small)) => {
+                        self.stack.push(IterItem::SmallNode(small.data.iter()));
                     }
                     Some(Entry::Collision(coll)) => {
                         self.collision = Some((coll.hash, coll.data.iter()));
@@ -527,9 +737,14 @@ impl<'a, A, P: SharedPointerKind> FusedIterator for Iter<'a, A, P> where A: 'a {
 
 // Mut ref iterator
 
+enum IterMutItem<'a, A, P: SharedPointerKind> {
+    Node(ChunkIterMut<'a, Entry<A, P>, HASH_WIDTH>),
+    SmallNode(ChunkIterMut<'a, Entry<A, P>, SMALL_NODE_WIDTH>),
+}
+
 pub(crate) struct IterMut<'a, A, P: SharedPointerKind> {
     count: usize,
-    stack: InlineStack<ChunkIterMut<'a, Entry<A, P>, HASH_WIDTH>>,
+    stack: InlineStack<IterMutItem<'a, A, P>>,
     collision: Option<(HashBits, SliceIterMut<'a, A>)>,
 }
 
@@ -545,7 +760,7 @@ where
             collision: None,
         };
         if let Some(node) = root {
-            result.stack.push(node.data.iter_mut());
+            result.stack.push(IterMutItem::Node(node.data.iter_mut()));
         }
         result
     }
@@ -571,14 +786,24 @@ where
             }
 
             while let Some(current) = self.stack.last_mut() {
-                match current.next() {
+                let next_entry = match current {
+                    IterMutItem::Node(iter) => iter.next(),
+                    IterMutItem::SmallNode(iter) => iter.next(),
+                };
+
+                match next_entry {
                     Some(Entry::Value(value, hash)) => {
                         self.count -= 1;
                         return Some((value, *hash));
                     }
                     Some(Entry::Node(child_ref)) => {
                         let child = SharedPointer::make_mut(child_ref);
-                        self.stack.push(child.data.iter_mut());
+                        self.stack.push(IterMutItem::Node(child.data.iter_mut()));
+                    }
+                    Some(Entry::SmallNode(small_ref)) => {
+                        let small = SharedPointer::make_mut(small_ref);
+                        self.stack
+                            .push(IterMutItem::SmallNode(small.data.iter_mut()));
                     }
                     Some(Entry::Collision(coll_ref)) => {
                         let coll = SharedPointer::make_mut(coll_ref);
@@ -605,10 +830,15 @@ impl<'a, A, P: SharedPointerKind> FusedIterator for IterMut<'a, A, P> where A: C
 
 // Consuming iterator
 
+enum DrainItem<A, P: SharedPointerKind> {
+    Node(SharedPointer<Node<A, P>, P>),
+    SmallNode(SharedPointer<SmallNode<A, P>, P>),
+    Collision(SharedPointer<CollisionNode<A>, P>),
+}
+
 pub(crate) struct Drain<A, P: SharedPointerKind> {
     count: usize,
-    stack: InlineStack<SharedPointer<Node<A, P>, P>>,
-    collision: Option<CollisionNode<A>>,
+    stack: InlineStack<DrainItem<A, P>>,
 }
 
 impl<A, P: SharedPointerKind> Drain<A, P> {
@@ -616,10 +846,9 @@ impl<A, P: SharedPointerKind> Drain<A, P> {
         let mut result = Drain {
             count: size,
             stack: InlineStack::new(),
-            collision: None,
         };
         if let Some(root) = root {
-            result.stack.push(root);
+            result.stack.push(DrainItem::Node(root));
         }
         result
     }
@@ -632,37 +861,45 @@ where
     type Item = (A, HashBits);
 
     fn next(&mut self) -> Option<Self::Item> {
-        'outer: loop {
-            if let Some(coll) = &mut self.collision {
-                match coll.data.pop() {
-                    None => self.collision = None,
-                    Some(value) => {
-                        self.count -= 1;
-                        return Some((value, coll.hash));
-                    }
-                };
-            }
-
-            while let Some(current) = self.stack.last_mut() {
-                match SharedPointer::make_mut(current).data.pop() {
+        while let Some(current) = self.stack.last_mut() {
+            match current {
+                DrainItem::Node(node_ref) => match SharedPointer::make_mut(node_ref).data.pop() {
                     Some(Entry::Value(value, hash)) => {
                         self.count -= 1;
                         return Some((value, hash));
                     }
                     Some(Entry::Node(child)) => {
-                        self.stack.push(child);
+                        self.stack.push(DrainItem::Node(child));
+                    }
+                    Some(Entry::SmallNode(small)) => {
+                        self.stack.push(DrainItem::SmallNode(small));
                     }
                     Some(Entry::Collision(coll)) => {
-                        self.collision = Some(clone_ref(coll));
-                        continue 'outer;
+                        self.stack.push(DrainItem::Collision(coll));
                     }
                     None => {
                         self.stack.pop();
                     }
+                },
+                DrainItem::SmallNode(small_ref) => {
+                    let small = SharedPointer::make_mut(small_ref);
+                    if let Some(Entry::Value(value, hash)) = small.data.pop() {
+                        self.count -= 1;
+                        return Some((value, hash));
+                    }
+                    self.stack.pop();
+                }
+                DrainItem::Collision(coll_ref) => {
+                    let coll = SharedPointer::make_mut(coll_ref);
+                    if let Some(value) = coll.data.pop() {
+                        self.count -= 1;
+                        return Some((value, coll.hash));
+                    }
+                    self.stack.pop();
                 }
             }
-            return None;
         }
+        None
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -683,21 +920,23 @@ impl<A: fmt::Debug, P: SharedPointerKind> fmt::Debug for Node<A, P> {
                 Entry::Value(v, h) => write!(f, "{:?} :: {}, ", v, h)?,
                 Entry::Collision(c) => write!(f, "Coll{:?} :: {}", c.data, c.hash)?,
                 Entry::Node(n) => write!(f, "{:?}, ", n)?,
+                Entry::SmallNode(s) => write!(f, "{:?}, ", s)?,
             }
         }
         write!(f, " ]")
     }
 }
 
-#[cfg(test)]
-impl<A, P: SharedPointerKind> Node<A, P> {
-    /// Analyze the node structure for debugging/statistics
-    pub(crate) fn analyze_structure<F>(&self, mut visitor: F)
-    where
-        F: FnMut(&Entry<A, P>),
-    {
+impl<A: fmt::Debug, P: SharedPointerKind> fmt::Debug for SmallNode<A, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "SmallNode[ ")?;
         for i in self.data.indices() {
-            visitor(&self.data[i]);
+            write!(f, "{}: ", i)?;
+            match &self.data[i] {
+                Entry::Value(v, h) => write!(f, "{:?} :: {}, ", v, h)?,
+                _ => unreachable!("SmallNode should only contain Values"),
+            }
         }
+        write!(f, " ]")
     }
 }

--- a/src/nodes/hamt.rs
+++ b/src/nodes/hamt.rs
@@ -688,3 +688,16 @@ impl<A: fmt::Debug, P: SharedPointerKind> fmt::Debug for Node<A, P> {
         write!(f, " ]")
     }
 }
+
+#[cfg(test)]
+impl<A, P: SharedPointerKind> Node<A, P> {
+    /// Analyze the node structure for debugging/statistics
+    pub(crate) fn analyze_structure<F>(&self, mut visitor: F)
+    where
+        F: FnMut(&Entry<A, P>),
+    {
+        for i in self.data.indices() {
+            visitor(&self.data[i]);
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces two significant optimizations to the HAMT implementation, targeting the large memory overhead (e.g., a node with 32 entry capacity has as few as two values). Classic HAMT implementations in GC languages (e.g. Clojure and Scala) have an easier time implementing dynamically sized dense nodes, but that's hard to do _efficiently_ in Rust. So I tried something different in this PR.

- Linear probing: Nodes will not immediately create a new node on the next level for collision resolution. If the load factor is small enough (<= 50%), store collisions inline using linear probing. This reduces tree depth and improves cache locality.
- Small nodes: Introduce half-width nodes (16 slots vs 32) to lower memory overhead for nodes with few entries. These also use linear probing and may eventually be upgraded to a full node.

### Performance Impact

Benchmark results are mixed and sensitive to the tree's shape (e.g., the average length of the leaves). Generally, regressions are minor and tend to reverse as the tree grows. There's one outliner, iterations can now be _more than twice_ as fast, and the gap widens with the tree size.

One caveat is worth mentioning: these benchmarks are entirely in the caches, so I suspect this change is a significant win in the real world. See the structure improvements section for details. 

<details>
<summary>Full benchmark comparison (old.txt vs new.txt)</summary>

```
name                            old.txt ns/iter  new.txt ns/iter  diff ns/iter   diff %  speedup
hashmap_i64/insert_100          36,674           36,454                   -220   -0.60%   x 1.01
hashmap_i64/insert_1000         650,404          684,837                34,433    5.29%   x 0.95
hashmap_i64/insert_10000        10,043,812       10,313,081            269,269    2.68%   x 0.97
hashmap_i64/insert_mut_100      4,670            4,546                    -124   -2.66%   x 1.03
hashmap_i64/insert_mut_1000     49,076           68,473                 19,397   39.52%   x 0.72
hashmap_i64/insert_mut_10000    488,274          609,559               121,285   24.84%   x 0.80
hashmap_i64/insert_mut_100000   10,231,091       7,815,478          -2,415,613  -23.61%   x 1.31
hashmap_i64/insert_once_100     51,213           49,884                 -1,329   -2.60%   x 1.03
hashmap_i64/insert_once_1000    74,358           74,701                    343    0.46%   x 1.00
hashmap_i64/insert_once_10000   111,630          108,240                -3,390   -3.04%   x 1.03
hashmap_i64/insert_once_100000  148,516          148,793                   277    0.19%   x 1.00
hashmap_i64/iter_1000           9,248            6,677                  -2,571  -27.80%   x 1.39
hashmap_i64/iter_10000          124,168          57,650                -66,518  -53.57%   x 2.15
hashmap_i64/lookup_100          924              1,018                      94   10.17%   x 0.91
hashmap_i64/lookup_1000         10,832           11,452                    620    5.72%   x 0.95
hashmap_i64/lookup_10000        169,830          152,287               -17,543  -10.33%   x 1.12
hashmap_i64/lookup_100000       3,384,124        3,129,824            -254,300   -7.51%   x 1.08
hashmap_i64/lookup_ne_10000     115,029          136,795                21,766   18.92%   x 0.84
hashmap_i64/lookup_ne_100000    3,060,550        3,206,496             145,946    4.77%   x 0.95
hashmap_i64/remove_100          32,878           33,099                    221    0.67%   x 0.99
hashmap_i64/remove_1000         646,983          681,351                34,368    5.31%   x 0.95
hashmap_i64/remove_10000        10,192,874       10,414,505            221,631    2.17%   x 0.98
hashmap_i64/remove_mut_100      5,388            5,195                    -193   -3.58%   x 1.04
hashmap_i64/remove_mut_1000     63,678           63,903                    225    0.35%   x 1.00
hashmap_i64/remove_mut_10000    724,822          648,197               -76,625  -10.57%   x 1.12
hashmap_i64/remove_once_100     51,245           50,783                   -462   -0.90%   x 1.01
hashmap_i64/remove_once_1000    74,682           76,184                  1,502    2.01%   x 0.98
hashmap_i64/remove_once_10000   112,374          109,724                -2,650   -2.36%   x 1.02
hashmap_i64/remove_once_100000  149,210          150,072                   862    0.58%   x 0.99
hashmap_str/insert_100          60,636           64,488                  3,852    6.35%   x 0.94
hashmap_str/insert_1000         904,168          987,117                82,949    9.17%   x 0.92
hashmap_str/insert_10000        12,157,712       13,085,436            927,724    7.63%   x 0.93
hashmap_str/insert_mut_100      8,459            8,682                     223    2.64%   x 0.97
hashmap_str/insert_mut_1000     94,922           120,193                25,271   26.62%   x 0.79
hashmap_str/insert_mut_10000    1,008,899        1,214,558             205,659   20.38%   x 0.83
hashmap_str/insert_mut_100000   20,957,934       22,010,455          1,052,521    5.02%   x 0.95
hashmap_str/insert_once_100     73,247           77,175                  3,928    5.36%   x 0.95
hashmap_str/insert_once_1000    110,855          116,021                 5,166    4.66%   x 0.96
hashmap_str/insert_once_10000   134,371          144,548                10,177    7.57%   x 0.93
hashmap_str/insert_once_100000  173,121          182,025                 8,904    5.14%   x 0.95
hashmap_str/iter_1000           9,440            6,763                  -2,677  -28.36%   x 1.40
hashmap_str/iter_10000          125,800          54,296                -71,504  -56.84%   x 2.32
hashmap_str/lookup_100          1,707            1,871                     164    9.61%   x 0.91
hashmap_str/lookup_1000         20,635           21,704                  1,069    5.18%   x 0.95
hashmap_str/lookup_10000        478,415          485,366                 6,951    1.45%   x 0.99
hashmap_str/lookup_100000       7,625,102        7,384,055            -241,047   -3.16%   x 1.03
hashmap_str/lookup_ne_10000     462,388          552,826                90,438   19.56%   x 0.84
hashmap_str/lookup_ne_100000    7,409,548        8,194,972             785,424   10.60%   x 0.90
hashmap_str/remove_100          61,865           63,399                  1,534    2.48%   x 0.98
hashmap_str/remove_1000         914,759          969,587                54,828    5.99%   x 0.94
hashmap_str/remove_10000        12,491,120       13,031,148            540,028    4.32%   x 0.96
hashmap_str/remove_mut_100      8,228            7,643                    -585   -7.11%   x 1.08
hashmap_str/remove_mut_1000     89,333           87,160                 -2,173   -2.43%   x 1.02
hashmap_str/remove_mut_10000    1,153,513        1,122,795             -30,718   -2.66%   x 1.03
hashmap_str/remove_once_100     74,302           75,726                  1,424    1.92%   x 0.98
hashmap_str/remove_once_1000    109,975          115,604                 5,629    5.12%   x 0.95
hashmap_str/remove_once_10000   133,261          144,233                10,972    8.23%   x 0.92
hashmap_str/remove_once_100000  171,927          179,839                 7,912    4.60%   x 0.96
```
</details>

### HAMT Structure Improvements

The optimizations significantly reduce tree depth, node count, and memory usage

100k entries comparison:
- Tree depth: 7 levels ->  4 levels
- Total nodes: 31066 ->  27608 (1185 big + 26423 small) (~89%)
- Memory usage difference (assuming `<u64, u64>`): (24 * 32 * 31066) -> (24 * 32 * 1185 + 24 * 16 * 26423) (**~46%**)

<details>
<summary>Old HAMT structure (oldsummary.txt)</summary>

=== Testing with 1000 entries ===
HashMap Structure Summary:
  Hash level size (bits): 5
  Branching factor: 32
  Total entries: 1000
  Tree depth: 4 levels

  Level 0:
    Nodes: 1
    Average entries per node: 32.00
    Entry types:
      Values: 0 (0.0%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 32 (100.0%)

  Level 1:
    Nodes: 32
    Average entries per node: 19.75
    Entry types:
      Values: 373 (59.0%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 259 (41.0%)

  Level 2:
    Nodes: 259
    Average entries per node: 2.37
    Entry types:
      Values: 601 (97.9%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 13 (2.1%)

  Level 3:
    Nodes: 13
    Average entries per node: 2.00
    Entry types:
      Values: 26 (100.0%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 0 (0.0%)

=== Testing with 10000 entries ===
HashMap Structure Summary:
  Hash level size (bits): 5
  Branching factor: 32
  Total entries: 10000
  Tree depth: 6 levels

  Level 0:
    Nodes: 1
    Average entries per node: 32.00
    Entry types:
      Values: 0 (0.0%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 32 (100.0%)

  Level 1:
    Nodes: 32
    Average entries per node: 32.00
    Entry types:
      Values: 0 (0.0%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 1024 (100.0%)

  Level 2:
    Nodes: 1024
    Average entries per node: 8.48
    Entry types:
      Values: 7477 (86.1%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 1205 (13.9%)

  Level 3:
    Nodes: 1205
    Average entries per node: 2.06
    Entry types:
      Values: 2441 (98.3%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 41 (1.7%)

  Level 4:
    Nodes: 41
    Average entries per node: 1.98
    Entry types:
      Values: 80 (98.8%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 1 (1.2%)

  Level 5:
    Nodes: 1
    Average entries per node: 2.00
    Entry types:
      Values: 2 (100.0%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 0 (0.0%)

=== Testing with 100000 entries ===
HashMap Structure Summary:
  Hash level size (bits): 5
  Branching factor: 32
  Total entries: 100000
  Tree depth: 7 levels

  Level 0:
    Nodes: 1
    Average entries per node: 32.00
    Entry types:
      Values: 0 (0.0%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 32 (100.0%)

  Level 1:
    Nodes: 32
    Average entries per node: 32.00
    Entry types:
      Values: 0 (0.0%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 1024 (100.0%)

  Level 2:
    Nodes: 1024
    Average entries per node: 30.54
    Entry types:
      Values: 4756 (15.2%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 26514 (84.8%)

  Level 3:
    Nodes: 26514
    Average entries per node: 3.42
    Entry types:
      Values: 86344 (95.2%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 4386 (4.8%)

  Level 4:
    Nodes: 4386
    Average entries per node: 2.00
    Entry types:
      Values: 8638 (98.5%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 131 (1.5%)

  Level 5:
    Nodes: 131
    Average entries per node: 1.97
    Entry types:
      Values: 254 (98.4%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 4 (1.6%)

  Level 6:
    Nodes: 4
    Average entries per node: 1.75
    Entry types:
      Values: 6 (85.7%)
      Collisions: 1 (avg len: 0.0) (14.3%)
      Child nodes: 0 (0.0%)
</details>

<details>
<summary>New HAMT structure (new_summary.txt)</summary>

=== Testing with 1000 entries ===
HashMap Structure Summary:
  Hash level size (bits): 5
  Branching factor: 32
  Total entries: 1000
  Tree depth: 2 levels

  Level 0:
    Nodes: 1
    Average entries per node: 32.00
    Entry types:
      Values: 0 (0.0%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 32 (100.0%)
      Small nodes: 0 (0.0%)

  Level 1:
    Nodes: 32
    Average entries per node: 19.50
    Entry types:
      Values: 350 (56.1%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 0 (0.0%)
      Small nodes: 274 (43.9%)
        → Avg entries per small node: 2.4

=== Testing with 10000 entries ===
HashMap Structure Summary:
  Hash level size (bits): 5
  Branching factor: 32
  Total entries: 10000
  Tree depth: 3 levels

  Level 0:
    Nodes: 1
    Average entries per node: 32.00
    Entry types:
      Values: 0 (0.0%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 32 (100.0%)
      Small nodes: 0 (0.0%)

  Level 1:
    Nodes: 32
    Average entries per node: 32.00
    Entry types:
      Values: 0 (0.0%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 638 (62.3%)
      Small nodes: 386 (37.7%)
        → Avg entries per small node: 6.6

  Level 2:
    Nodes: 638
    Average entries per node: 11.55
    Entry types:
      Values: 7285 (98.9%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 0 (0.0%)
      Small nodes: 82 (1.1%)
        → Avg entries per small node: 2.2

=== Testing with 100000 entries ===
HashMap Structure Summary:
  Hash level size (bits): 5
  Branching factor: 32
  Total entries: 100000
  Tree depth: 4 levels

  Level 0:
    Nodes: 1
    Average entries per node: 32.00
    Entry types:
      Values: 0 (0.0%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 32 (100.0%)
      Small nodes: 0 (0.0%)

  Level 1:
    Nodes: 32
    Average entries per node: 32.00
    Entry types:
      Values: 0 (0.0%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 1024 (100.0%)
      Small nodes: 0 (0.0%)

  Level 2:
    Nodes: 1024
    Average entries per node: 30.53
    Entry types:
      Values: 4710 (15.1%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 128 (0.4%)
      Small nodes: 26423 (84.5%)
        → Avg entries per small node: 3.6

  Level 3:
    Nodes: 128
    Average entries per node: 9.41
    Entry types:
      Values: 1204 (100.0%)
      Collisions: 0 (avg len: 0.0) (0.0%)
      Child nodes: 0 (0.0%)
      Small nodes: 0 (0.0%)
</details>

### 67% Load Factor Experiment

I also benchmarked a 67% load factor for linear probing vs. the default 50%. Benchmark caveats regarding tree shape and caches apply here. Most changes are neutral, but degradation on lookups is noticeable due to linear probing overhead, so I ended up sticking to 50%.

<details>
<summary>67% load factor comparison (new_but_67pct.txt)</summary>

```
name                            new.txt ns/iter  new2.txt ns/iter  diff ns/iter   diff %  speedup
hashmap_i64/insert_100          36,454           36,032                    -422   -1.16%   x 1.01
hashmap_i64/insert_1000         684,837          676,532                 -8,305   -1.21%   x 1.01
hashmap_i64/insert_10000        10,313,081       10,216,016             -97,065   -0.94%   x 1.01
hashmap_i64/insert_mut_100      4,546            4,653                      107    2.35%   x 0.98
hashmap_i64/insert_mut_1000     68,473           73,145                   4,672    6.82%   x 0.94
hashmap_i64/insert_mut_10000    609,559          565,574                -43,985   -7.22%   x 1.08
hashmap_i64/insert_mut_100000   7,815,478        8,484,241              668,763    8.56%   x 0.92
hashmap_i64/insert_once_100     49,884           50,987                   1,103    2.21%   x 0.98
hashmap_i64/insert_once_1000    74,701           74,665                     -36   -0.05%   x 1.00
hashmap_i64/insert_once_10000   108,240          108,972                    732    0.68%   x 0.99
hashmap_i64/insert_once_100000  148,793          148,444                   -349   -0.23%   x 1.00
hashmap_i64/iter_1000           6,677            6,718                       41    0.61%   x 0.99
hashmap_i64/iter_10000          57,650           57,440                    -210   -0.36%   x 1.00
hashmap_i64/lookup_100          1,018            1,014                       -4   -0.39%   x 1.00
hashmap_i64/lookup_1000         11,452           11,370                     -82   -0.72%   x 1.01
hashmap_i64/lookup_10000        152,287          151,536                   -751   -0.49%   x 1.00
hashmap_i64/lookup_100000       3,129,824        3,064,338              -65,486   -2.09%   x 1.02
hashmap_i64/lookup_ne_10000     136,795          169,682                 32,887   24.04%   x 0.81
hashmap_i64/lookup_ne_100000    3,206,496        3,280,121               73,625    2.30%   x 0.98
hashmap_i64/remove_100          33,099           33,451                     352    1.06%   x 0.99
hashmap_i64/remove_1000         681,351          675,396                 -5,955   -0.87%   x 1.01
hashmap_i64/remove_10000        10,414,505       10,460,268              45,763    0.44%   x 1.00
hashmap_i64/remove_mut_100      5,195            5,258                       63    1.21%   x 0.99
hashmap_i64/remove_mut_1000     63,903           62,977                    -926   -1.45%   x 1.01
hashmap_i64/remove_mut_10000    648,197          646,686                 -1,511   -0.23%   x 1.00
hashmap_i64/remove_once_100     50,783           50,916                     133    0.26%   x 1.00
hashmap_i64/remove_once_1000    76,184           76,470                     286    0.38%   x 1.00
hashmap_i64/remove_once_10000   109,724          111,153                  1,429    1.30%   x 0.99
hashmap_i64/remove_once_100000  150,072          149,687                   -385   -0.26%   x 1.00
hashmap_str/insert_100          64,488           64,466                     -22   -0.03%   x 1.00
hashmap_str/insert_1000         987,117          1,010,971               23,854    2.42%   x 0.98
hashmap_str/insert_10000        13,085,436       12,965,795            -119,641   -0.91%   x 1.01
hashmap_str/insert_mut_100      8,682            8,802                      120    1.38%   x 0.99
hashmap_str/insert_mut_1000     120,193          123,404                  3,211    2.67%   x 0.97
hashmap_str/insert_mut_10000    1,214,558        1,120,601              -93,957   -7.74%   x 1.08
hashmap_str/insert_mut_100000   22,010,455       18,341,241          -3,669,214  -16.67%   x 1.20
hashmap_str/insert_once_100     77,175           76,730                    -445   -0.58%   x 1.01
hashmap_str/insert_once_1000    116,021          115,940                    -81   -0.07%   x 1.00
hashmap_str/insert_once_10000   144,548          143,945                   -603   -0.42%   x 1.00
hashmap_str/insert_once_100000  182,025          180,745                 -1,280   -0.70%   x 1.01
hashmap_str/iter_1000           6,763            6,711                      -52   -0.77%   x 1.01
hashmap_str/iter_10000          54,296           57,563                   3,267    6.02%   x 0.94
hashmap_str/lookup_100          1,871            1,833                      -38   -2.03%   x 1.02
hashmap_str/lookup_1000         21,704           21,769                      65    0.30%   x 1.00
hashmap_str/lookup_10000        485,366          527,179                 41,813    8.61%   x 0.92
hashmap_str/lookup_100000       7,384,055        8,347,594              963,539   13.05%   x 0.88
hashmap_str/lookup_ne_10000     552,826          595,473                 42,647    7.71%   x 0.93
hashmap_str/lookup_ne_100000    8,194,972        9,424,734            1,229,762   15.01%   x 0.87
hashmap_str/remove_100          63,399           63,054                    -345   -0.54%   x 1.01
hashmap_str/remove_1000         969,587          960,954                 -8,633   -0.89%   x 1.01
hashmap_str/remove_10000        13,031,148       13,064,696              33,548    0.26%   x 1.00
hashmap_str/remove_mut_100      7,643            7,698                       55    0.72%   x 0.99
hashmap_str/remove_mut_1000     87,160           86,427                    -733   -0.84%   x 1.01
hashmap_str/remove_mut_10000    1,122,795        1,118,232               -4,563   -0.41%   x 1.00
hashmap_str/remove_once_100     75,726           76,056                     330    0.44%   x 1.00
hashmap_str/remove_once_1000    115,604          114,292                 -1,312   -1.13%   x 1.01
hashmap_str/remove_once_10000   144,233          143,046                 -1,187   -0.82%   x 1.01
hashmap_str/remove_once_100000  179,839          179,726                   -113   -0.06%   x 1.00
```
</details>

## Implementation Details

- `GenericNode<A, P, const WIDTH>`: Parameterized node type supporting different widths. E.g. `SmallNode<A, P>`: Type alias for half-width nodes (WIDTH=16)
- Automatic upgrade from linear probing to classic Node is based on load factor
- When linear probing is being used, deletions are handled with backward shift
- Re-activating linear probing once a node shrinks below the threshold is tricky, so a basic version was implemented.
- To reduce linear probing overhead (e.g. for String like keys) hash comparisons are performed
