### PR TITLE
Remove default features for bincode.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,18 +50,8 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
- "bincode_derive",
  "serde",
  "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
 ]
 
 [[package]]
@@ -851,12 +841,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1", optional = true }
 rayon = { version = "1", optional = true }
 refpool = { version = "0.4", optional = true }
 arbitrary = { version = "1.0", optional = true }
-bincode = {version = "2.0.1", optional = true }
+bincode = {version = "2.0.1", optional = true, default-features=false, features = ["alloc", "std"]}
 
 [dev-dependencies]
 proptest = "1.0"


### PR DESCRIPTION
When I specified `bincode` as an optional dependency, I didn't think of opting out of default features. As a result, any project using `imbl` with the `bincode` feature can't opt out of `bincode`s optional features either. This pull request fixes it.