### PR TITLE
Remove unused optional dependency refpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,6 @@ dependencies = [
  "rand_core 0.9.0",
  "rand_xoshiro",
  "rayon",
- "refpool",
  "rpds",
  "serde",
  "serde_json",
@@ -648,12 +647,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "refpool"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369e86b80fa7dc8c561dd9613a5bf25c59d2d3073cd66c47fd9e39802f0ecb58"
 
 [[package]]
 name = "regex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ quickcheck = { version = "1.0", optional = true }
 proptest = { version = "1.0", optional = true }
 serde = { version = "1", optional = true }
 rayon = { version = "1", optional = true }
-refpool = { version = "0.4", optional = true }
 arbitrary = { version = "1.0", optional = true }
 bincode = {version = "2.0.1", optional = true, default-features=false, features = ["alloc", "std"]}
 


### PR DESCRIPTION
Technically a breaking change because the presence of this optional dependency means that there's a Cargo feature of the same name (that does nothing).