### PR TITLE
Use optimized binary search for non-trivial types in B+Tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
       - name: cargo fmt
         run: cargo fmt --check
 


### PR DESCRIPTION
As of https://github.com/rust-lang/rust/pull/128254 stdlib binary search is heavily optimized for integers but is not optimal when more complex comparison functions are used.

This PR adds a custom binary search implementation that performs the minimal/optimal number of comparisons (std doesn't) and also may early return on equality matches. To prevent regressions, the code delegates to stdlib for simple to compare types.


## Benchmark Results

Using Arc\<String\> keyed maps

Successful Lookups (lookup)

| Size | stdlib-only (ns) | full-custom (ns) | Improvement |
|------|------------------|------------------|-------------|
| 100 | 6,914.78 | 3,250.84 | **-52.99%** (2.13x faster) |
| 1,000 | 136,864.94 | 70,691.21 | **-48.35%** (1.94x faster) |
| 10,000 | 2,551,756.59 | 1,384,791.19 | **-45.73%** (1.84x faster) |
| 100,000 | 53,456,691.83 | 32,561,327.23 | **-39.09%** (1.64x faster) |

Unsuccessful Lookups (lookup_ne)

| Size | stdlib-only (ns) | full-custom (ns) | Improvement |
|------|------------------|------------------|-------------|
| 10,000 | 1,257,900.25 | 951,632.31 | **-24.35%** (1.32x faster) |
| 100,000 | 20,290,911.64 | 17,732,490.51 | **-12.61%** (1.14x faster) |

### Raw Data

```
ordmap_str/lookup_100:
  stdlib-only:          6,914.78 ns
  full-custom:          3,250.84 ns  (-52.99%, 2.13x)

ordmap_str/lookup_1000:
  stdlib-only:        136,864.94 ns
  full-custom:         70,691.21 ns  (-48.35%, 1.94x)

ordmap_str/lookup_10000:
  stdlib-only:      2,551,756.59 ns
  full-custom:      1,384,791.19 ns  (-45.73%, 1.84x)

ordmap_str/lookup_100000:
  stdlib-only:     53,456,691.83 ns
  full-custom:     32,561,327.23 ns  (-39.09%, 1.64x)

ordmap_str/lookup_ne_10000:
  stdlib-only:      1,257,900.25 ns
  full-custom:        951,632.31 ns  (-24.35%, 1.32x)

ordmap_str/lookup_ne_100000:
  stdlib-only:     20,290,911.64 ns
  full-custom:     17,732,490.51 ns  (-12.61%, 1.14x)
```
