### PR TITLE
Adjust B-tree node size to optimize for immutable operations

### DIFF
--- a/benches/ordmap.rs
+++ b/benches/ordmap.rs
@@ -567,7 +567,7 @@ where
     }
 
     if M::IMMUTABLE {
-        for size in &[100, 1000, 10000] {
+        for size in &[100, 1000, 10000, 100000] {
             group.bench_function(format!("insert_{}", size), |b| {
                 bench_insert::<M, K, V>(b, *size)
             });

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,8 +14,12 @@ pub(crate) const VECTOR_CHUNK_SIZE: usize = 64;
 // Must be an even number!
 #[cfg(feature = "small-chunks")]
 pub(crate) const ORD_CHUNK_SIZE: usize = 6;
+// Value of 16 chosen based on performance analysis. Larger nodes might improve lookup slightly
+// and bulk mutable operations more so, but suffers severe copy overhead for small mutations.
+// Under typical workloads (e.g. 70% lookup, 25% small mutation, 5% bulk mutation), 16 arguably
+// provides the best balance.
 #[cfg(not(feature = "small-chunks"))]
-pub(crate) const ORD_CHUNK_SIZE: usize = 64;
+pub(crate) const ORD_CHUNK_SIZE: usize = 16;
 
 /// The level size of HAMTs, in bits
 /// Branching factor is 2 ^ HashLevelSize.
@@ -23,5 +27,9 @@ pub(crate) const ORD_CHUNK_SIZE: usize = 64;
 // (half the size of a full node) requires at least 4 slots.
 #[cfg(feature = "small-chunks")]
 pub(crate) const HASH_LEVEL_SIZE: usize = 3;
+// Value of 5 (branching factor 32) chosen based on performance analysis. Smaller value 4
+// (branching factor 16) improves immutable inserts by 16-25% but suffers severe lookup
+// regressions. Under typical workloads (e.g. 70% lookup, 25% small mutation, 5% bulk mutation),
+// 5 is arguably better overall.
 #[cfg(not(feature = "small-chunks"))]
 pub(crate) const HASH_LEVEL_SIZE: usize = 5;


### PR DESCRIPTION
This PR aims to lower the BTree node size from 64 to 16 to significantly speed up immutable operations. There are many tradeoffs to this, so there are a number of data points below.

16 seems to be the best option for a default, assuming bulk mutable ops on map<int, int> are rare. 32 could also be considered a good default that is not too bad in any benchmark.

Note: All benchmarks below were conducted with #143 

### Integer Keys (i64)

Lookup


| Size | node16 (ns) | node24 (ns) | node32 (ns) | node64 (ns) |
|------|-------------|-------------|-------------|-------------|
| 1,000 | 16,893.98 | 17,549.98 (+3.88%) | 14,938.43 (-11.58%) | 12,885.78 (-23.73%) |
| 10,000 | 266,911.55 | 265,269.35 (-0.62%) | 237,677.90 (-10.95%) | 214,610.08 (-19.60%) |
| 100,000 | 4,194,661.15 | 4,314,662.85 (+2.86%) | 3,843,491.42 (-8.37%) | 3,665,503.21 (-12.62%) |

Insert (Immutable rebuild)


| Size | node16 (ns) | node24 (ns) | node32 (ns) | node64 (ns) |
|------|-------------|-------------|-------------|-------------|
| 1,000 | 258,504.50 | 254,569.34 (-1.52%) | 272,045.05 (+5.24%) | 263,698.47 (+2.01%) |
| 10,000 | 4,012,321.84 | 4,252,352.24 (+5.98%) | 4,554,603.13 (+13.52%) | 5,830,210.18 (**+45.31%**) |
| 100,000 | 55,151,000.00 | 59,770,000.00 (+8.38%) | 63,770,000.00 (+15.63%) | 85,436,000.00 (**+54.91%**) |

Insert_mut (Mutable Rebuild)

| Size | node16 (ns) | node24 (ns) | node32 (ns) | node64 (ns) |
|------|-------------|-------------|-------------|-------------|
| 1,000 | 34,321.42 | 30,092.26 (-12.32%) | 26,570.18 (-22.58%) | 21,956.10 (**-36.03%**) |
| 10,000 | 466,929.53 | 419,148.57 (-10.23%) | 366,932.72 (-21.42%) | 326,670.42 (**-30.04%**) |
| 100,000 | 6,559,422.63 | 5,780,881.89 (-11.87%) | 5,233,060.62 (-20.22%) | 4,501,900.68 (**-31.37%**) |

### String Keys (Arc\<String\>)

Lookup

| Size | node16 (ns) | node24 (ns) | node32 (ns) | node64 (ns) |
|------|-------------|-------------|-------------|-------------|
| 1,000 | 73,607.57 | 72,639.68 (-1.31%) | 71,289.13 (-3.15%) | 69,995.56 (-4.91%) |
| 10,000 | 1,455,809.02 | 1,479,449.72 (+1.62%) | 1,409,748.56 (-3.16%) | 1,360,139.02 (-6.57%) |
| 100,000 | 27,896,198.21 | 28,564,354.59 (+2.40%) | 27,582,292.49 (-1.13%) | 27,854,836.80 (-0.15%) |

Insert (Immutable rebuild)

| Size | node16 (ns) | node24 (ns) | node32 (ns) | node64 (ns) |
|------|-------------|-------------|-------------|-------------|
| 1,000 | 643,998.20 | 738,174.59 (+14.62%) | 868,265.69 (**+34.82%**) | 1,169,707.31 (**+81.63%**) |
| 10,000 | 8,990,128.46 | 10,588,391.59 (+17.78%) | 12,317,527.90 (**+37.01%**) | 17,893,880.07 (**+99.04%**) |
| 100,000 | 126,590,000.00 | 148,010,000.00 (+16.92%) | 166,590,000.00 (**+31.60%**) | 257,850,000.00 (**+103.69%**) |

Insert_mut (Mutable Rebuild)

| Size | node16 (ns) | node24 (ns) | node32 (ns) | node64 (ns) |
|------|-------------|-------------|-------------|-------------|
| 1,000 | 98,446.48 | 90,152.90 (-8.42%) | 86,822.18 (-11.81%) | 80,408.26 (-18.32%) |
| 10,000 | 1,342,836.98 | 1,268,787.93 (-5.51%) | 1,210,009.80 (-9.89%) | 1,149,962.19 (-14.36%) |
| 100,000 | 18,605,674.25 | 16,621,725.84 (-10.66%) | 15,906,407.79 (-14.51%) | 15,641,137.49 (-15.93%) |

### Key observations

- Immutable insert penalty scales with both node size and collection size (worse at 100K than at 1K), while mutable operations show the inverse relationship.
- Lookup performance converges at 100K scale for strings (all node sizes within 2.5% of each other)
- **node16**: Best for immutable inserts. Worst-case: +56% (i64_insert_mut_1000).
- **node24**: slightly worse for immutable inserts without sufficient lookup gains. Most balanced worst-case profile (+37% at i64_insert_mut_1000).
- **node32**: worse for immutable inserts (8% at insert_100000, 32% at str_insert_100000) with lookup improvements on ints (12% at i64_lookup_100000). Worst-case: +37% (str_insert_10000).
- **node64**: severe loss on immutable inserts (55% at i64_insert_100000, 104% at str_insert_100000), better lookup performance with int keys (24% at i64_lookup_1000). Worst-case: +104% (str_insert_100000).

