### PR TITLE
Default Argument and CHUNK_SIZE Refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [stable, beta, nightly, 1.85]
+        rust: [stable, beta, nightly, 1.89]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [stable, beta, nightly, 1.85]
+        rust: [stable, beta, nightly, 1.89]
         os: [ubuntu-latest]
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,9 +71,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitmaps"
@@ -128,18 +128,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.49"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
+checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.49"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
+checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -750,9 +750,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,30 +19,30 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "archery"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae2ed21cd55021f05707a807a5fc85695dafb98832921f6cfa06db67ca5b869"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
 dependencies = [
  "triomphe",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bincode"
@@ -71,9 +71,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bitmaps"
@@ -88,12 +88,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,9 +95,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "ciborium"
@@ -134,18 +128,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.43"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.43"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -159,25 +153,22 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -185,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
  "itertools",
@@ -232,9 +223,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_logger"
@@ -248,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
@@ -270,42 +261,37 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets",
+ "r-efi",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "e54c115d4f30f52c67202f079c5f9d8b49db4691f460fdb0b4c2e838261b2ba5"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "imbl"
@@ -323,8 +309,8 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "quickcheck",
- "rand 0.9.0",
- "rand_core 0.9.0",
+ "rand 0.9.2",
+ "rand_core 0.9.3",
  "rand_xoshiro",
  "rayon",
  "rpds",
@@ -344,36 +330,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -387,27 +362,27 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "metrohash"
@@ -426,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
@@ -466,11 +441,11 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -485,26 +460,26 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.9.2",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -542,12 +517,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -555,30 +536,17 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.0",
- "zerocopy 0.8.17",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -588,7 +556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -597,26 +565,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.1",
- "zerocopy 0.8.17",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
 name = "rand_xorshift"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -625,14 +592,14 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -640,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -650,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -662,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -673,24 +640,24 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rpds"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e15515d3ce3313324d842629ea4905c25a13f81953eadb88f85516f59290a4"
+checksum = "acb4efcdbf5d5489a878f48686e08e0e38da594e98295235b5aeeabe905fbff6"
 dependencies = [
  "archery",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
@@ -707,9 +674,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
  "quick-error",
@@ -719,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -734,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.224"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaeb1e94f53b16384af593c71e20b095e958dab1d26939c1b70645c5cfbcc0b"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -744,18 +711,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.224"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f39390fa6346e24defbcdd3d9544ba8a19985d0af74df8501fbfe9a64341ab"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.224"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ff78ab5e8561c9a675bfc1785cb07ae721f0ee53329a595cefd8c04c2ac4e0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -764,14 +731,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -782,9 +750,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -793,13 +761,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -817,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "triomphe"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
 
 [[package]]
 name = "unarray"
@@ -829,9 +796,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unty"
@@ -866,36 +833,46 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -907,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -917,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -930,18 +907,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -949,94 +926,33 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
-dependencies = [
- "bitflags",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "yansi"
@@ -1046,39 +962,18 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
-dependencies = [
- "zerocopy-derive 0.8.17",
+ "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "ciborium"
@@ -128,18 +128,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.48"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.48"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "criterion"
@@ -267,26 +267,26 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.7+wasi-0.2.4",
+ "wasip2",
 ]
 
 [[package]]
 name = "half"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54c115d4f30f52c67202f079c5f9d8b49db4691f460fdb0b4c2e838261b2ba5"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -362,9 +362,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "linux-raw-sys"
@@ -574,7 +574,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rpds"
@@ -766,7 +766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -836,15 +836,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
 
 [[package]]
 name = "wasip2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "imbl"
-version = "6.1.0"
+version = "6.2.0"
 dependencies = [
  "arbitrary",
  "archery",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -19,9 +19,15 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -31,9 +37,9 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "archery"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae2ed21cd55021f05707a807a5fc85695dafb98832921f6cfa06db67ca5b869"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
 dependencies = [
  "triomphe",
 ]
@@ -71,9 +77,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.2"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitmaps"
@@ -83,15 +89,15 @@ checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "cast"
@@ -101,9 +107,20 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.0",
+]
 
 [[package]]
 name = "ciborium"
@@ -134,18 +151,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -153,9 +170,18 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "criterion"
@@ -234,13 +260,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "env_logger"
-version = "0.8.4"
+name = "env_filter"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
 dependencies = [
  "log",
  "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+dependencies = [
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -251,12 +287,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -272,41 +308,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "getrandom"
-version = "0.2.16"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
-]
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "imbl"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "arbitrary",
  "archery",
@@ -321,8 +394,8 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "quickcheck",
- "rand 0.9.2",
- "rand_core 0.9.3",
+ "rand 0.10.0",
+ "rand_core 0.10.0",
  "rand_xoshiro",
  "rayon",
  "rpds",
@@ -343,6 +416,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,49 +438,49 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metrohash"
@@ -472,24 +557,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.101"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags",
- "lazy_static",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha",
@@ -519,20 +613,20 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quickcheck"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
 dependencies = [
  "env_logger",
  "log",
- "rand 0.8.5",
+ "rand 0.10.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -545,21 +639,23 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -569,26 +665,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.3",
-]
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_xorshift"
@@ -596,16 +689,16 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+checksum = "1f0b2cc7bfeef8f0320ca45f88b00157a03c67137022d59393614352d6bf4312"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -630,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -642,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -653,30 +746,30 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rpds"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e15515d3ce3313324d842629ea4905c25a13f81953eadb88f85516f59290a4"
+checksum = "9e75f485e819d4d3015e6c0d55d02a4fd3db47c1993d9e603e0361fba2bffb34"
 dependencies = [
  "archery",
 ]
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -687,9 +780,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
  "quick-error",
@@ -698,16 +791,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
 name = "safe_arch"
-version = "0.7.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
 dependencies = [
  "bytemuck",
 ]
@@ -722,10 +809,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.224"
+name = "semver"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaeb1e94f53b16384af593c71e20b095e958dab1d26939c1b70645c5cfbcc0b"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -733,18 +826,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.224"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f39390fa6346e24defbcdd3d9544ba8a19985d0af74df8501fbfe9a64341ab"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.224"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ff78ab5e8561c9a675bfc1785cb07ae721f0ee53329a595cefd8c04c2ac4e0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -753,14 +846,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -771,9 +865,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -782,15 +876,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -805,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "triomphe"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
 
 [[package]]
 name = "unarray"
@@ -817,9 +911,15 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unty"
@@ -853,51 +953,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -905,31 +995,65 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -937,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.33"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+checksum = "ac11b009ebeae802ed758530b6496784ebfee7a87b9abfbcaf3bbe25b814eb25"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -947,173 +1071,114 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
  "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1124,20 +1189,26 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,10 @@ proptest = { version = "1.0", optional = true }
 serde_core = { version = "1.0.224", optional = true }
 rayon = { version = "1", optional = true }
 arbitrary = { version = "1.0", optional = true }
-bincode = {version = "2.0.1", optional = true, default-features=false, features = ["alloc", "std"]}
+bincode = { version = "2.0.1", optional = true, default-features = false, features = [
+    "alloc",
+    "std",
+] }
 
 [dev-dependencies]
 proptest = "1.0"
@@ -64,9 +67,9 @@ proptest-derive = "0.6"
 static_assertions = "1.1.0"
 # criterion, rpds and half versions are fixed to the latest versions
 # that work with the current minimum Rust version
-criterion = "0.5"
-rpds = { version = "=1.1.0" }
-half = "=2.4"
+criterion = "0.7"
+rpds = { version = "1.1.0" }
+half = "2.7"
 
 # Include debug symbols when benchmarking, this is useful for profiling
 [profile.bench]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Joe Neeman <joeneeman@gmail.com>",
     "Arthur Silva <arthurprs@gmail.com>",
 ]
-edition = "2018"
+edition = "2024"
 license = "MPL-2.0+"
 rust-version = "1.85"
 description = "Immutable collection datatypes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imbl"
-version = "6.1.0"
+version = "6.2.0"
 authors = [
     "Bodil Stokke <bodil@bodil.org>",
     "Joe Neeman <joeneeman@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Joe Neeman <joeneeman@gmail.com>",
     "Arthur Silva <arthurprs@gmail.com>",
 ]
-edition = "2018"
+edition = "2024"
 license = "MPL-2.0+"
 rust-version = "1.85"
 description = "Immutable collection datatypes"
@@ -50,7 +50,10 @@ proptest = { version = "1.0", optional = true }
 serde_core = { version = "1.0.224", optional = true }
 rayon = { version = "1", optional = true }
 arbitrary = { version = "1.0", optional = true }
-bincode = {version = "2.0.1", optional = true, default-features=false, features = ["alloc", "std"]}
+bincode = { version = "2.0.1", optional = true, default-features = false, features = [
+    "alloc",
+    "std",
+] }
 wide = "0.7"
 equivalent = "1.0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imbl"
-version = "7.0.0"
+version = "8.0.0"
 authors = [
     "Bodil Stokke <bodil@bodil.org>",
     "Joe Neeman <joeneeman@gmail.com>",
@@ -8,7 +8,7 @@ authors = [
 ]
 edition = "2024"
 license = "MPL-2.0+"
-rust-version = "1.85"
+rust-version = "1.89"
 description = "Immutable collection datatypes"
 repository = "https://github.com/jneem/imbl"
 documentation = "https://docs.rs/imbl"
@@ -42,8 +42,8 @@ triomphe = ["archery/triomphe"]
 [dependencies]
 bitmaps = "3"
 imbl-sized-chunks = "0.1.3"
-rand_core = "0.9"
-rand_xoshiro = "0.7"
+rand_core = "0.10"
+rand_xoshiro = "0.8"
 archery = "1.2.1"
 quickcheck = { version = "1.0", optional = true }
 proptest = { version = "1.0", optional = true }
@@ -54,7 +54,7 @@ bincode = { version = "2.0.1", optional = true, default-features = false, featur
     "alloc",
     "std",
 ] }
-wide = "0.7"
+wide = "1.1"
 equivalent = "1.0.2"
 
 [dev-dependencies]
@@ -62,7 +62,7 @@ proptest = "1.0"
 serde_core = "1"
 serde_json = "1"
 rayon = "1"
-rand = { version = "0.9", features = ["small_rng"] }
+rand = { version = "0.10" }
 pretty_assertions = "1.0"
 metrohash = "1"
 proptest-derive = "0.6"

--- a/benches/hashmap.rs
+++ b/benches/hashmap.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use criterion::{Bencher, Criterion, criterion_group, criterion_main};
 use imbl::hashmap::HashMap;
 use std::borrow::Borrow;
 use std::collections::HashMap as StdHashMap;

--- a/benches/ordmap.rs
+++ b/benches/ordmap.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use criterion::{Bencher, Criterion, criterion_group, criterion_main};
 use equivalent::Comparable;
 use imbl::ordmap::OrdMap;
 use std::borrow::Borrow;

--- a/benches/utils/mod.rs
+++ b/benches/utils/mod.rs
@@ -2,7 +2,7 @@
 
 use rand::distr::{Distribution, StandardUniform};
 use rand::seq::SliceRandom;
-use rand::{rngs::SmallRng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, rngs::SmallRng};
 use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -23,10 +23,10 @@ pub trait TestData: Clone + Debug + Ord + Eq + Hash {
 
 impl TestData for i64 {
     fn generate(size: usize) -> Vec<Self> {
-        let mut gen = SmallRng::seed_from_u64(1);
+        let mut rng = SmallRng::seed_from_u64(1);
         let mut set = BTreeSet::new();
         while set.len() < size {
-            let next = gen.random::<i64>();
+            let next = rng.random::<i64>();
             set.insert(next);
         }
         set.into_iter().collect()
@@ -35,12 +35,12 @@ impl TestData for i64 {
 
 impl TestData for String {
     fn generate(size: usize) -> Vec<Self> {
-        let mut gen = SmallRng::seed_from_u64(1);
+        let mut rng = SmallRng::seed_from_u64(1);
         let mut set = BTreeSet::new();
         while set.len() < size {
-            let len = gen.random_range(5..20);
+            let len = rng.random_range(5..20);
             let s: String = (0..len)
-                .map(|_| gen.random_range(b'a'..=b'z') as char)
+                .map(|_| rng.random_range(b'a'..=b'z') as char)
                 .collect();
             set.insert(s);
         }
@@ -58,8 +58,8 @@ where
 }
 
 pub fn reorder<A: Clone>(vec: &[A]) -> Vec<A> {
-    let mut gen = SmallRng::seed_from_u64(1);
+    let mut rng = SmallRng::seed_from_u64(1);
     let mut out = vec.to_vec();
-    out.shuffle(&mut gen);
+    out.shuffle(&mut rng);
     out
 }

--- a/benches/vector.rs
+++ b/benches/vector.rs
@@ -1,7 +1,6 @@
-use criterion::{criterion_group, criterion_main, Bencher, Criterion};
-use imbl::shared_ptr::DefaultSharedPtr;
-use imbl::vector::Vector;
+use criterion::{Bencher, Criterion, criterion_group, criterion_main};
 use imbl::GenericVector;
+use imbl::shared_ptr::DefaultSharedPtr;
 use rand::seq::SliceRandom;
 use std::collections::VecDeque;
 use std::hint::black_box;

--- a/benches/vector.rs
+++ b/benches/vector.rs
@@ -1,5 +1,5 @@
 use criterion::{Bencher, Criterion, criterion_group, criterion_main};
-use imbl::GenericVector;
+use imbl::Vector;
 use imbl::shared_ptr::DefaultSharedPtr;
 use rand::seq::SliceRandom;
 use std::collections::VecDeque;
@@ -67,7 +67,7 @@ impl<'a, T: Clone, const CHUNK_SIZE: usize> VectorFocusMut<'a, T, CHUNK_SIZE> {
 
 // Implementation for imbl::Vector
 impl<T: Clone, const CHUNK_SIZE: usize> BenchVector<T, CHUNK_SIZE>
-    for GenericVector<T, DefaultSharedPtr, CHUNK_SIZE>
+    for Vector<T, DefaultSharedPtr, CHUNK_SIZE>
 {
     type Iter<'a>
         = imbl::vector::Iter<'a, T, imbl::shared_ptr::DefaultSharedPtr, CHUNK_SIZE>
@@ -75,7 +75,7 @@ impl<T: Clone, const CHUNK_SIZE: usize> BenchVector<T, CHUNK_SIZE>
         T: 'a;
 
     fn new() -> Self {
-        GenericVector::new()
+        Vector::new()
     }
 
     fn push_front(&mut self, value: T) {
@@ -405,8 +405,8 @@ fn bench_ops_group<V: BenchVector<usize, DEFAULT_CHUNK>>(c: &mut Criterion, grou
 
 // Benchmark functions for each vector type
 fn bench_vector(c: &mut Criterion) {
-    bench_sort_group::<GenericVector<usize, DefaultSharedPtr, DEFAULT_CHUNK>>(c, "vector");
-    bench_ops_group::<GenericVector<usize, DefaultSharedPtr, DEFAULT_CHUNK>>(c, "vector");
+    bench_sort_group::<Vector<usize, DefaultSharedPtr, DEFAULT_CHUNK>>(c, "vector");
+    bench_ops_group::<Vector<usize, DefaultSharedPtr, DEFAULT_CHUNK>>(c, "vector");
 }
 
 fn bench_vecdeque(c: &mut Criterion) {

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -2,17 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use arbitrary::{size_hint, Arbitrary, Result, Unstructured};
+use arbitrary::{Arbitrary, Result, Unstructured, size_hint};
 use std::hash::{BuildHasher, Hash};
 
-use crate::{
-    shared_ptr::SharedPointerKind, GenericHashMap, GenericHashSet, GenericOrdMap, GenericOrdSet,
-    GenericVector,
-};
+use crate::{HashMap, HashSet, OrdMap, OrdSet, Vector, shared_ptr::SharedPointerKind};
 
-impl<'a, A: Arbitrary<'a> + Clone, P: SharedPointerKind + 'static> Arbitrary<'a>
-    for GenericVector<A, P>
-{
+impl<'a, A: Arbitrary<'a> + Clone, P: SharedPointerKind + 'static> Arbitrary<'a> for Vector<A, P> {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         u.arbitrary_iter()?.collect()
     }
@@ -28,12 +23,8 @@ impl<'a, A: Arbitrary<'a> + Clone, P: SharedPointerKind + 'static> Arbitrary<'a>
     }
 }
 
-impl<
-        'a,
-        K: Arbitrary<'a> + Ord + Clone,
-        V: Arbitrary<'a> + Clone,
-        P: SharedPointerKind + 'static,
-    > Arbitrary<'a> for GenericOrdMap<K, V, P>
+impl<'a, K: Arbitrary<'a> + Ord + Clone, V: Arbitrary<'a> + Clone, P: SharedPointerKind + 'static>
+    Arbitrary<'a> for OrdMap<K, V, P>
 {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         u.arbitrary_iter()?.collect()
@@ -51,7 +42,7 @@ impl<
 }
 
 impl<'a, A: Arbitrary<'a> + Ord + Clone, P: SharedPointerKind + 'static> Arbitrary<'a>
-    for GenericOrdSet<A, P>
+    for OrdSet<A, P>
 {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         u.arbitrary_iter()?.collect()
@@ -68,7 +59,7 @@ impl<'a, A: Arbitrary<'a> + Ord + Clone, P: SharedPointerKind + 'static> Arbitra
     }
 }
 
-impl<'a, K, V, S, P> Arbitrary<'a> for GenericHashMap<K, V, S, P>
+impl<'a, K, V, S, P> Arbitrary<'a> for HashMap<K, V, S, P>
 where
     K: Arbitrary<'a> + Hash + Eq + Clone,
     V: Arbitrary<'a> + Clone,
@@ -90,7 +81,7 @@ where
     }
 }
 
-impl<'a, A, S, P> Arbitrary<'a> for GenericHashSet<A, S, P>
+impl<'a, A, S, P> Arbitrary<'a> for HashSet<A, S, P>
 where
     A: Arbitrary<'a> + Hash + Eq + Clone,
     S: BuildHasher + Clone + Default + 'static,

--- a/src/bincode.rs
+++ b/src/bincode.rs
@@ -10,15 +10,15 @@ use bincode::enc::Encoder;
 use bincode::error::{DecodeError, EncodeError};
 use bincode::{Decode, Encode};
 
-use crate::hashmap::GenericHashMap;
-use crate::hashset::GenericHashSet;
-use crate::ordmap::GenericOrdMap;
-use crate::ordset::GenericOrdSet;
-use crate::vector::GenericVector;
+use crate::hashmap::HashMap;
+use crate::hashset::HashSet;
+use crate::ordmap::OrdMap;
+use crate::ordset::OrdSet;
+use crate::vector::Vector;
 
 // Set
 
-impl<C, A: Decode<C> + Ord + Clone, P: SharedPointerKind> Decode<C> for GenericOrdSet<A, P> {
+impl<C, A: Decode<C> + Ord + Clone, P: SharedPointerKind> Decode<C> for OrdSet<A, P> {
     fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let mut output = Self::new();
         let length: usize = Decode::decode(decoder)?;
@@ -31,7 +31,7 @@ impl<C, A: Decode<C> + Ord + Clone, P: SharedPointerKind> Decode<C> for GenericO
     }
 }
 
-impl<A: Ord + Encode, P: SharedPointerKind> Encode for GenericOrdSet<A, P> {
+impl<A: Ord + Encode, P: SharedPointerKind> Encode for OrdSet<A, P> {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
         Encode::encode(&self.len(), encoder)?;
         for item in self.iter() {
@@ -44,7 +44,7 @@ impl<A: Ord + Encode, P: SharedPointerKind> Encode for GenericOrdSet<A, P> {
 // Map
 
 impl<C, K: Decode<C> + Ord + Clone, V: Decode<C> + Clone, P: SharedPointerKind> Decode<C>
-    for GenericOrdMap<K, V, P>
+    for OrdMap<K, V, P>
 {
     fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let len: usize = Decode::decode(decoder)?;
@@ -58,9 +58,7 @@ impl<C, K: Decode<C> + Ord + Clone, V: Decode<C> + Clone, P: SharedPointerKind> 
     }
 }
 
-impl<K: Encode + Ord + Clone, V: Encode + Clone, P: SharedPointerKind> Encode
-    for GenericOrdMap<K, V, P>
-{
+impl<K: Encode + Ord + Clone, V: Encode + Clone, P: SharedPointerKind> Encode for OrdMap<K, V, P> {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
         Encode::encode(&self.len(), encoder)?;
         for (k, v) in self.iter() {
@@ -72,7 +70,7 @@ impl<K: Encode + Ord + Clone, V: Encode + Clone, P: SharedPointerKind> Encode
 
 // HashMap
 
-impl<C, K, V, S, P: SharedPointerKind> Decode<C> for GenericHashMap<K, V, S, P>
+impl<C, K, V, S, P: SharedPointerKind> Decode<C> for HashMap<K, V, S, P>
 where
     K: Decode<C> + Hash + Eq + Clone,
     V: Decode<C> + Clone,
@@ -91,7 +89,7 @@ where
     }
 }
 
-impl<K, V, S, P> Encode for GenericHashMap<K, V, S, P>
+impl<K, V, S, P> Encode for HashMap<K, V, S, P>
 where
     K: Encode + Hash + Eq,
     V: Encode,
@@ -109,7 +107,7 @@ where
 
 // HashSet
 
-impl<C, A, S, P> Decode<C> for GenericHashSet<A, S, P>
+impl<C, A, S, P> Decode<C> for HashSet<A, S, P>
 where
     A: Decode<C> + Hash + Eq + Clone,
     S: BuildHasher + Default + Clone,
@@ -128,7 +126,7 @@ where
 }
 
 impl<A: Encode + Hash + Eq, S: BuildHasher + Default, P: SharedPointerKind> Encode
-    for GenericHashSet<A, S, P>
+    for HashSet<A, S, P>
 {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
         Encode::encode(&self.len(), encoder)?;
@@ -141,7 +139,7 @@ impl<A: Encode + Hash + Eq, S: BuildHasher + Default, P: SharedPointerKind> Enco
 
 // Vector
 
-impl<C, A: Clone + Decode<C>, P: SharedPointerKind> Decode<C> for GenericVector<A, P> {
+impl<C, A: Clone + Decode<C>, P: SharedPointerKind> Decode<C> for Vector<A, P> {
     fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let mut output = Self::new();
         let length: usize = Decode::decode(decoder)?;
@@ -153,7 +151,7 @@ impl<C, A: Clone + Decode<C>, P: SharedPointerKind> Decode<C> for GenericVector<
     }
 }
 
-impl<A: Encode, P: SharedPointerKind> Encode for GenericVector<A, P> {
+impl<A: Encode, P: SharedPointerKind> Encode for Vector<A, P> {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
         Encode::encode(&self.len(), encoder)?;
         for item in self.iter() {
@@ -168,8 +166,8 @@ impl<A: Encode, P: SharedPointerKind> Encode for GenericVector<A, P> {
 #[cfg(test)]
 mod test {
     use crate::{
-        proptest::{hash_map, hash_set, ord_map, ord_set, vector},
         HashMap, HashSet, OrdMap, OrdSet, Vector,
+        proptest::{hash_map, hash_set, ord_map, ord_set, vector},
     };
     use bincode::{decode_from_slice, encode_to_vec};
     use proptest::num::i32;

--- a/src/hash/map.rs
+++ b/src/hash/map.rs
@@ -33,8 +33,8 @@ use std::ops::{Add, Index, IndexMut};
 use archery::{SharedPointer, SharedPointerKind};
 
 use crate::nodes::hamt::{
-    hash_key, Drain as NodeDrain, HashBits, HashValue, Iter as NodeIter, IterMut as NodeIterMut,
-    Node,
+    Drain as NodeDrain, HashBits, HashValue, Iter as NodeIter, IterMut as NodeIterMut, Node,
+    hash_key,
 };
 use crate::shared_ptr::DefaultSharedPtr;
 
@@ -725,9 +725,7 @@ where
         BK: Hash + Eq + ?Sized,
         K: Borrow<BK>,
     {
-        let Some(root) = self.root.as_mut() else {
-            return None;
-        };
+        let root = self.root.as_mut()?;
         match SharedPointer::make_mut(root).get_mut(hash_key(&self.hasher, key), 0, key) {
             None => None,
             Some((key, value)) => Some((key, value)),
@@ -1576,7 +1574,7 @@ where
         F: FnOnce(&mut V),
     {
         match &mut self {
-            Entry::Occupied(ref mut entry) => f(entry.get_mut()),
+            Entry::Occupied(entry) => f(entry.get_mut()),
             Entry::Vacant(_) => (),
         }
         self

--- a/src/hash/map.rs
+++ b/src/hash/map.rs
@@ -102,7 +102,7 @@ pub type HashMap<K, V> = GenericHashMap<K, V, RandomState, DefaultSharedPtr>;
 /// [std::cmp::Eq]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
 /// [std::hash::Hash]: https://doc.rust-lang.org/std/hash/trait.Hash.html
 /// [std::collections::hash_map::RandomState]: https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html
-pub struct GenericHashMap<K, V, S, P: SharedPointerKind> {
+pub struct GenericHashMap<K, V, S = RandomState, P: SharedPointerKind = DefaultSharedPtr> {
     size: usize,
     root: Option<SharedPointer<Node<(K, V), P>, P>>,
     hasher: S,

--- a/src/hash/map.rs
+++ b/src/hash/map.rs
@@ -53,7 +53,7 @@ use crate::shared_ptr::DefaultSharedPtr;
 ///     2 => 22,
 ///     3 => 33
 ///   },
-///   HashMap::from(vec![(1, 11), (2, 22), (3, 33)])
+///   HashMap::<_, _>::from(vec![(1, 11), (2, 22), (3, 33)])
 /// );
 /// # }
 /// ```
@@ -78,13 +78,6 @@ macro_rules! hashmap {
     }};
 }
 
-/// Type alias for [`GenericHashMap`] that uses [`std::hash::RandomState`] as the default hasher and [`DefaultSharedPtr`] as the pointer type.
-///
-/// [GenericHashMap]: ./struct.GenericHashMap.html
-/// [`std::hash::RandomState`]: https://doc.rust-lang.org/stable/std/collections/hash_map/struct.RandomState.html
-/// [DefaultSharedPtr]: ../shared_ptr/type.DefaultSharedPtr.html
-pub type HashMap<K, V> = GenericHashMap<K, V, RandomState, DefaultSharedPtr>;
-
 /// An unordered map.
 ///
 /// An immutable hash map using [hash array mapped tries] [1].
@@ -103,7 +96,7 @@ pub type HashMap<K, V> = GenericHashMap<K, V, RandomState, DefaultSharedPtr>;
 /// [std::cmp::Eq]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
 /// [std::hash::Hash]: https://doc.rust-lang.org/std/hash/trait.Hash.html
 /// [std::collections::hash_map::RandomState]: https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html
-pub struct GenericHashMap<K, V, S = RandomState, P: SharedPointerKind = DefaultSharedPtr> {
+pub struct HashMap<K, V, S = RandomState, P: SharedPointerKind = DefaultSharedPtr> {
     size: usize,
     root: Option<SharedPointer<Node<(K, V), P>, P>>,
     hasher: S,
@@ -124,7 +117,7 @@ where
     }
 }
 
-impl<K, V, P> GenericHashMap<K, V, RandomState, P>
+impl<K, V, P> HashMap<K, V, RandomState, P>
 where
     K: Hash + Eq + Clone,
     V: Clone,
@@ -137,7 +130,7 @@ where
     /// ```
     /// # #[macro_use] extern crate imbl;
     /// # use imbl::HashMap;
-    /// let map = HashMap::unit(123, "onetwothree");
+    /// let map = HashMap::<_, _>::unit(123, "onetwothree");
     /// assert_eq!(
     ///   map.get(&123),
     ///   Some(&"onetwothree")
@@ -145,22 +138,43 @@ where
     /// ```
     #[inline]
     #[must_use]
-    pub fn unit(k: K, v: V) -> GenericHashMap<K, V, RandomState, P> {
-        GenericHashMap::new().update(k, v)
+    pub fn unit(k: K, v: V) -> HashMap<K, V, RandomState, P> {
+        HashMap::with_kind().update(k, v)
     }
 }
 
-impl<K, V, S, P: SharedPointerKind> GenericHashMap<K, V, S, P> {
-    /// Construct an empty hash map.
+impl<K, V> HashMap<K, V, RandomState, DefaultSharedPtr> {
+    /// Construct an empty hash map using the default hasher and shared kind
     #[inline]
     #[must_use]
-    pub fn new() -> Self
-    where
-        S: Default,
-    {
+    pub fn new() -> Self {
         Self::default()
     }
+}
 
+impl<K, V, P: SharedPointerKind> HashMap<K, V, RandomState, P> {
+    /// Construct an empty hash map using a custom shared kind
+    #[inline]
+    #[must_use]
+    pub fn with_kind() -> Self {
+        Self::default()
+    }
+}
+
+impl<K, V, S> HashMap<K, V, S, DefaultSharedPtr> {
+    /// Construct an empty hash map using the provided hasher.
+    #[inline]
+    #[must_use]
+    pub fn with_hasher(hasher: S) -> Self {
+        HashMap {
+            size: 0,
+            hasher,
+            root: None,
+        }
+    }
+}
+
+impl<K, V, S, P: SharedPointerKind> HashMap<K, V, S, P> {
     /// Test whether a hash map is empty.
     ///
     /// Time: O(1)
@@ -221,11 +235,11 @@ impl<K, V, S, P: SharedPointerKind> GenericHashMap<K, V, S, P> {
         }
     }
 
-    /// Construct an empty hash map using the provided hasher.
+    /// Construct an empty hash map using a custom shared kind and the provided hasher.
     #[inline]
     #[must_use]
-    pub fn with_hasher(hasher: S) -> Self {
-        GenericHashMap {
+    pub fn with_hasher_and_kind(hasher: S) -> Self {
+        HashMap {
             size: 0,
             hasher,
             root: None,
@@ -244,13 +258,13 @@ impl<K, V, S, P: SharedPointerKind> GenericHashMap<K, V, S, P> {
     /// current hash map.
     #[inline]
     #[must_use]
-    pub fn new_from<K1, V1>(&self) -> GenericHashMap<K1, V1, S, P>
+    pub fn new_from<K1, V1>(&self) -> HashMap<K1, V1, S, P>
     where
         K1: Hash + Eq + Clone,
         V1: Clone,
         S: Clone,
     {
-        GenericHashMap {
+        HashMap {
             size: 0,
             root: None,
             hasher: self.hasher.clone(),
@@ -474,7 +488,7 @@ impl<K, V, S, P: SharedPointerKind> GenericHashMap<K, V, S, P> {
     }
 }
 
-impl<K, V, S, P> GenericHashMap<K, V, S, P>
+impl<K, V, S, P> HashMap<K, V, S, P>
 where
     K: Hash + Eq,
     S: BuildHasher + Clone,
@@ -482,7 +496,7 @@ where
 {
     fn test_eq<S2: BuildHasher + Clone, P2: SharedPointerKind>(
         &self,
-        other: &GenericHashMap<K, V, S2, P2>,
+        other: &HashMap<K, V, S2, P2>,
     ) -> bool
     where
         V: PartialEq,
@@ -598,7 +612,7 @@ where
     pub fn is_submap_by<B, RM, F, P2: SharedPointerKind>(&self, other: RM, mut cmp: F) -> bool
     where
         F: FnMut(&V, &B) -> bool,
-        RM: Borrow<GenericHashMap<K, B, S, P2>>,
+        RM: Borrow<HashMap<K, B, S, P2>>,
     {
         self.iter()
             .all(|(k, v)| other.borrow().get(k).map(|ov| cmp(v, ov)).unwrap_or(false))
@@ -616,7 +630,7 @@ where
     pub fn is_proper_submap_by<B, RM, F, P2: SharedPointerKind>(&self, other: RM, cmp: F) -> bool
     where
         F: FnMut(&V, &B) -> bool,
-        RM: Borrow<GenericHashMap<K, B, S, P2>>,
+        RM: Borrow<HashMap<K, B, S, P2>>,
     {
         self.len() != other.borrow().len() && self.is_submap_by(other, cmp)
     }
@@ -677,7 +691,7 @@ where
     }
 }
 
-impl<K, V, S, P> GenericHashMap<K, V, S, P>
+impl<K, V, S, P> HashMap<K, V, S, P>
 where
     K: Hash + Eq + Clone,
     V: Clone,
@@ -1457,9 +1471,9 @@ where
     #[must_use]
     pub fn intersection_with<B, C, F>(
         self,
-        other: GenericHashMap<K, B, S, P>,
+        other: HashMap<K, B, S, P>,
         mut f: F,
-    ) -> GenericHashMap<K, C, S, P>
+    ) -> HashMap<K, C, S, P>
     where
         B: Clone,
         C: Clone,
@@ -1490,9 +1504,9 @@ where
     #[must_use]
     pub fn intersection_with_key<B, C, F>(
         mut self,
-        other: GenericHashMap<K, B, S, P>,
+        other: HashMap<K, B, S, P>,
         mut f: F,
-    ) -> GenericHashMap<K, C, S, P>
+    ) -> HashMap<K, C, S, P>
     where
         B: Clone,
         C: Clone,
@@ -1605,7 +1619,7 @@ where
     S: BuildHasher + Clone,
     P: SharedPointerKind,
 {
-    map: &'a mut GenericHashMap<K, V, S, P>,
+    map: &'a mut HashMap<K, V, S, P>,
     hash: HashBits,
     key: K,
 }
@@ -1681,7 +1695,7 @@ where
     S: BuildHasher + Clone,
     P: SharedPointerKind,
 {
-    map: &'a mut GenericHashMap<K, V, S, P>,
+    map: &'a mut HashMap<K, V, S, P>,
     hash: HashBits,
     key: K,
 }
@@ -1723,7 +1737,7 @@ where
 
 // Core traits
 
-impl<K, V, S, P> Clone for GenericHashMap<K, V, S, P>
+impl<K, V, S, P> Clone for HashMap<K, V, S, P>
 where
     K: Clone,
     V: Clone,
@@ -1735,7 +1749,7 @@ where
     /// Time: O(1)
     #[inline]
     fn clone(&self) -> Self {
-        GenericHashMap {
+        HashMap {
             root: self.root.clone(),
             size: self.size,
             hasher: self.hasher.clone(),
@@ -1743,7 +1757,7 @@ where
     }
 }
 
-impl<K, V, S1, S2, P1, P2> PartialEq<GenericHashMap<K, V, S2, P2>> for GenericHashMap<K, V, S1, P1>
+impl<K, V, S1, S2, P1, P2> PartialEq<HashMap<K, V, S2, P2>> for HashMap<K, V, S1, P1>
 where
     K: Hash + Eq,
     V: PartialEq,
@@ -1752,12 +1766,12 @@ where
     P1: SharedPointerKind,
     P2: SharedPointerKind,
 {
-    fn eq(&self, other: &GenericHashMap<K, V, S2, P2>) -> bool {
+    fn eq(&self, other: &HashMap<K, V, S2, P2>) -> bool {
         self.test_eq(other)
     }
 }
 
-impl<K, V, S, P> Eq for GenericHashMap<K, V, S, P>
+impl<K, V, S, P> Eq for HashMap<K, V, S, P>
 where
     K: Hash + Eq,
     V: Eq,
@@ -1766,14 +1780,14 @@ where
 {
 }
 
-impl<K, V, S, P> Default for GenericHashMap<K, V, S, P>
+impl<K, V, S, P> Default for HashMap<K, V, S, P>
 where
     S: Default,
     P: SharedPointerKind,
 {
     #[inline]
     fn default() -> Self {
-        GenericHashMap {
+        HashMap {
             size: 0,
             root: None,
             hasher: Default::default(),
@@ -1781,35 +1795,35 @@ where
     }
 }
 
-impl<K, V, S, P> Add for GenericHashMap<K, V, S, P>
+impl<K, V, S, P> Add for HashMap<K, V, S, P>
 where
     K: Hash + Eq + Clone,
     V: Clone,
     S: BuildHasher + Clone,
     P: SharedPointerKind,
 {
-    type Output = GenericHashMap<K, V, S, P>;
+    type Output = HashMap<K, V, S, P>;
 
     fn add(self, other: Self) -> Self::Output {
         self.union(other)
     }
 }
 
-impl<K, V, S, P> Add for &GenericHashMap<K, V, S, P>
+impl<K, V, S, P> Add for &HashMap<K, V, S, P>
 where
     K: Hash + Eq + Clone,
     V: Clone,
     S: BuildHasher + Clone,
     P: SharedPointerKind,
 {
-    type Output = GenericHashMap<K, V, S, P>;
+    type Output = HashMap<K, V, S, P>;
 
     fn add(self, other: Self) -> Self::Output {
         self.clone().union(other.clone())
     }
 }
 
-impl<K, V, S, P> Sum for GenericHashMap<K, V, S, P>
+impl<K, V, S, P> Sum for HashMap<K, V, S, P>
 where
     K: Hash + Eq + Clone,
     V: Clone,
@@ -1824,7 +1838,7 @@ where
     }
 }
 
-impl<K, V, S, RK, RV, P> Extend<(RK, RV)> for GenericHashMap<K, V, S, P>
+impl<K, V, S, RK, RV, P> Extend<(RK, RV)> for HashMap<K, V, S, P>
 where
     K: Hash + Eq + Clone + From<RK>,
     V: Clone + From<RV>,
@@ -1841,7 +1855,7 @@ where
     }
 }
 
-impl<Q, K, V, S, P> Index<&Q> for GenericHashMap<K, V, S, P>
+impl<Q, K, V, S, P> Index<&Q> for HashMap<K, V, S, P>
 where
     Q: Hash + Equivalent<K> + ?Sized,
     K: Hash + Eq,
@@ -1858,7 +1872,7 @@ where
     }
 }
 
-impl<Q, K, V, S, P> IndexMut<&Q> for GenericHashMap<K, V, S, P>
+impl<Q, K, V, S, P> IndexMut<&Q> for HashMap<K, V, S, P>
 where
     Q: Hash + Equivalent<K> + ?Sized,
     K: Hash + Eq + Clone,
@@ -1874,7 +1888,7 @@ where
     }
 }
 
-impl<K, V, S, P> Debug for GenericHashMap<K, V, S, P>
+impl<K, V, S, P> Debug for HashMap<K, V, S, P>
 where
     K: Debug,
     V: Debug,
@@ -2040,7 +2054,7 @@ impl<'a, K, V, P: SharedPointerKind> ExactSizeIterator for Values<'a, K, V, P> {
 
 impl<'a, K, V, P: SharedPointerKind> FusedIterator for Values<'a, K, V, P> {}
 
-impl<'a, K, V, S, P: SharedPointerKind> IntoIterator for &'a GenericHashMap<K, V, S, P> {
+impl<'a, K, V, S, P: SharedPointerKind> IntoIterator for &'a HashMap<K, V, S, P> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V, P>;
 
@@ -2050,7 +2064,7 @@ impl<'a, K, V, S, P: SharedPointerKind> IntoIterator for &'a GenericHashMap<K, V
     }
 }
 
-impl<K, V, S, P> IntoIterator for GenericHashMap<K, V, S, P>
+impl<K, V, S, P> IntoIterator for HashMap<K, V, S, P>
 where
     K: Hash + Eq + Clone,
     V: Clone,
@@ -2070,7 +2084,7 @@ where
 
 // Conversions
 
-impl<K, V, S, P> FromIterator<(K, V)> for GenericHashMap<K, V, S, P>
+impl<K, V, S, P> FromIterator<(K, V)> for HashMap<K, V, S, P>
 where
     K: Hash + Eq + Clone,
     V: Clone,
@@ -2089,17 +2103,14 @@ where
     }
 }
 
-impl<K, V, S, P: SharedPointerKind> AsRef<GenericHashMap<K, V, S, P>>
-    for GenericHashMap<K, V, S, P>
-{
+impl<K, V, S, P: SharedPointerKind> AsRef<HashMap<K, V, S, P>> for HashMap<K, V, S, P> {
     #[inline]
     fn as_ref(&self) -> &Self {
         self
     }
 }
 
-impl<K, V, OK, OV, SA, SB, P1, P2> From<&GenericHashMap<&K, &V, SA, P1>>
-    for GenericHashMap<OK, OV, SB, P2>
+impl<K, V, OK, OV, SA, SB, P1, P2> From<&HashMap<&K, &V, SA, P1>> for HashMap<OK, OV, SB, P2>
 where
     K: Hash + Equivalent<OK> + ToOwned<Owned = OK> + ?Sized,
     V: ToOwned<Owned = OV> + ?Sized,
@@ -2110,14 +2121,14 @@ where
     P1: SharedPointerKind,
     P2: SharedPointerKind,
 {
-    fn from(m: &GenericHashMap<&K, &V, SA, P1>) -> Self {
+    fn from(m: &HashMap<&K, &V, SA, P1>) -> Self {
         m.iter()
             .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
             .collect()
     }
 }
 
-impl<'a, K, V, S, P> From<&'a [(K, V)]> for GenericHashMap<K, V, S, P>
+impl<'a, K, V, S, P> From<&'a [(K, V)]> for HashMap<K, V, S, P>
 where
     K: Hash + Eq + Clone,
     V: Clone,
@@ -2129,7 +2140,7 @@ where
     }
 }
 
-impl<K, V, S, P> From<Vec<(K, V)>> for GenericHashMap<K, V, S, P>
+impl<K, V, S, P> From<Vec<(K, V)>> for HashMap<K, V, S, P>
 where
     K: Hash + Eq + Clone,
     V: Clone,
@@ -2141,7 +2152,7 @@ where
     }
 }
 
-impl<'a, K, V, S, P> From<&'a Vec<(K, V)>> for GenericHashMap<K, V, S, P>
+impl<'a, K, V, S, P> From<&'a Vec<(K, V)>> for HashMap<K, V, S, P>
 where
     K: Hash + Eq + Clone,
     V: Clone,
@@ -2153,7 +2164,7 @@ where
     }
 }
 
-impl<K, V, S1, S2, P> From<collections::HashMap<K, V, S2>> for GenericHashMap<K, V, S1, P>
+impl<K, V, S1, S2, P> From<collections::HashMap<K, V, S2>> for HashMap<K, V, S1, P>
 where
     K: Hash + Eq + Clone,
     V: Clone,
@@ -2166,7 +2177,7 @@ where
     }
 }
 
-impl<'a, K, V, S1, S2, P> From<&'a collections::HashMap<K, V, S2>> for GenericHashMap<K, V, S1, P>
+impl<'a, K, V, S1, S2, P> From<&'a collections::HashMap<K, V, S2>> for HashMap<K, V, S1, P>
 where
     K: Hash + Eq + Clone,
     V: Clone,
@@ -2179,7 +2190,7 @@ where
     }
 }
 
-impl<K, V, S, P> From<collections::BTreeMap<K, V>> for GenericHashMap<K, V, S, P>
+impl<K, V, S, P> From<collections::BTreeMap<K, V>> for HashMap<K, V, S, P>
 where
     K: Hash + Eq + Clone,
     V: Clone,
@@ -2191,7 +2202,7 @@ where
     }
 }
 
-impl<'a, K, V, S, P> From<&'a collections::BTreeMap<K, V>> for GenericHashMap<K, V, S, P>
+impl<'a, K, V, S, P> From<&'a collections::BTreeMap<K, V>> for HashMap<K, V, S, P>
 where
     K: Hash + Eq + Clone,
     V: Clone,
@@ -2251,7 +2262,7 @@ mod test {
 
     #[test]
     fn safe_mutation() {
-        let v1: HashMap<usize, usize> = GenericHashMap::from_iter((0..131_072).map(|i| (i, i)));
+        let v1: HashMap<usize, usize> = HashMap::from_iter((0..131_072).map(|i| (i, i)));
         let mut v2 = v1.clone();
         v2.insert(131_000, 23);
         assert_eq!(Some(&23), v2.get(&131_000));
@@ -2283,8 +2294,8 @@ mod test {
         for (k, v) in &pairs {
             m.insert(*k, *v);
         }
-        let mut map: GenericHashMap<i16, i16, _, DefaultSharedPtr> =
-            GenericHashMap::with_hasher(BuildHasherDefault::<LolHasher>::default());
+        let mut map: HashMap<i16, i16, _, DefaultSharedPtr> =
+            HashMap::with_hasher(BuildHasherDefault::<LolHasher>::default());
         for (k, v) in &m {
             map = map.update(*k, *v);
         }
@@ -2321,7 +2332,7 @@ mod test {
     #[test]
     fn remove_top_level_collisions() {
         let pairs = vec![9, 2569, 27145];
-        let mut map: GenericHashMap<i16, i16, BuildHasherDefault<LolHasher>, DefaultSharedPtr> =
+        let mut map: HashMap<i16, i16, BuildHasherDefault<LolHasher>, DefaultSharedPtr> =
             Default::default();
         for k in pairs.clone() {
             map.insert(k, k);
@@ -2412,7 +2423,7 @@ mod test {
     proptest! {
         #[test]
         fn update_and_length(ref m in collection::hash_map(i16::ANY, i16::ANY, 0..1000)) {
-            let mut map: GenericHashMap<i16, i16, BuildHasherDefault<LolHasher>, DefaultSharedPtr> = Default::default();
+            let mut map: HashMap<i16, i16, BuildHasherDefault<LolHasher>, DefaultSharedPtr> = Default::default();
             for (index, (k, v)) in m.iter().enumerate() {
                 map = map.update(*k, *v);
                 assert_eq!(Some(v), map.get(k));
@@ -2455,7 +2466,7 @@ mod test {
             for (k, v) in pairs {
                 m.insert(*k, *v);
             }
-            let mut map: GenericHashMap<i16, i16, _, DefaultSharedPtr> = GenericHashMap::with_hasher(BuildHasherDefault::<LolHasher>::default());
+            let mut map: HashMap<i16, i16, _, DefaultSharedPtr> = HashMap::with_hasher(BuildHasherDefault::<LolHasher>::default());
             for (k, v) in &m {
                 map = map.update(*k, *v);
             }
@@ -2470,8 +2481,8 @@ mod test {
 
         #[test]
         fn insert(ref m in collection::hash_map(i16::ANY, i16::ANY, 0..1000)) {
-            let mut mut_map: GenericHashMap<i16, i16, BuildHasherDefault<LolHasher>, DefaultSharedPtr> = Default::default();
-            let mut map: GenericHashMap<i16, i16, BuildHasherDefault<LolHasher>, DefaultSharedPtr> = Default::default();
+            let mut mut_map: HashMap<i16, i16, BuildHasherDefault<LolHasher>, DefaultSharedPtr> = Default::default();
+            let mut map: HashMap<i16, i16, BuildHasherDefault<LolHasher>, DefaultSharedPtr> = Default::default();
             for (count, (k, v)) in m.iter().enumerate() {
                 map = map.update(*k, *v);
                 mut_map.insert(*k, *v);
@@ -2492,7 +2503,7 @@ mod test {
             for (k, v) in pairs {
                 m.insert(*k, *v);
             }
-            let mut map: GenericHashMap<i16, i16, _, DefaultSharedPtr> = GenericHashMap::with_hasher(BuildHasherDefault::<LolHasher>::default());
+            let mut map: HashMap<i16, i16, _, DefaultSharedPtr> = HashMap::with_hasher(BuildHasherDefault::<LolHasher>::default());
             for (k, v) in &m {
                 map.insert(*k, *v);
             }

--- a/src/hash/set.rs
+++ b/src/hash/set.rs
@@ -945,26 +945,28 @@ where
     }
 }
 
-impl<A, S, P1, P2> From<GenericVector<A, P2>> for GenericHashSet<A, S, P1>
+impl<A, S, P1, P2, const CHUNK_SIZE: usize> From<GenericVector<A, P2, CHUNK_SIZE>>
+    for GenericHashSet<A, S, P1>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher + Default + Clone,
     P1: SharedPointerKind,
     P2: SharedPointerKind,
 {
-    fn from(vector: GenericVector<A, P2>) -> Self {
+    fn from(vector: GenericVector<A, P2, CHUNK_SIZE>) -> Self {
         vector.into_iter().collect()
     }
 }
 
-impl<A, S, P1, P2> From<&GenericVector<A, P2>> for GenericHashSet<A, S, P1>
+impl<A, S, P1, P2, const CHUNK_SIZE: usize> From<&GenericVector<A, P2, CHUNK_SIZE>>
+    for GenericHashSet<A, S, P1>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher + Default + Clone,
     P1: SharedPointerKind,
     P2: SharedPointerKind,
 {
-    fn from(vector: &GenericVector<A, P2>) -> Self {
+    fn from(vector: &GenericVector<A, P2, CHUNK_SIZE>) -> Self {
         vector.iter().cloned().collect()
     }
 }

--- a/src/hash/set.rs
+++ b/src/hash/set.rs
@@ -32,9 +32,9 @@ use std::ops::{Add, Deref, Mul};
 use archery::{SharedPointer, SharedPointerKind};
 use equivalent::Equivalent;
 
-use crate::GenericVector;
+use crate::Vector;
 use crate::nodes::hamt::{Drain as NodeDrain, HashValue, Iter as NodeIter, Node, hash_key};
-use crate::ordset::GenericOrdSet;
+use crate::ordset::OrdSet;
 use crate::shared_ptr::DefaultSharedPtr;
 
 /// Construct a set from a sequence of values.
@@ -47,7 +47,7 @@ use crate::shared_ptr::DefaultSharedPtr;
 /// # fn main() {
 /// assert_eq!(
 ///   hashset![1, 2, 3],
-///   HashSet::from(vec![1, 2, 3])
+///   HashSet::<_>::from(vec![1, 2, 3])
 /// );
 /// # }
 /// ```
@@ -72,13 +72,6 @@ macro_rules! hashset {
     }};
 }
 
-/// Type alias for [`GenericHashSet`] that uses [`std::hash::RandomState`] as the default hasher and [`DefaultSharedPtr`] as the pointer type.
-///
-/// [GenericHashSet]: ./struct.GenericHashSet.html
-/// [`std::hash::RandomState`]: https://doc.rust-lang.org/stable/std/collections/hash_map/struct.RandomState.html
-/// [DefaultSharedPtr]: ../shared_ptr/type.DefaultSharedPtr.html
-pub type HashSet<A> = GenericHashSet<A, RandomState, DefaultSharedPtr>;
-
 /// An unordered set.
 ///
 /// An immutable hash set using [hash array mapped tries] [1].
@@ -97,7 +90,7 @@ pub type HashSet<A> = GenericHashSet<A, RandomState, DefaultSharedPtr>;
 /// [std::cmp::Eq]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
 /// [std::hash::Hash]: https://doc.rust-lang.org/std/hash/trait.Hash.html
 /// [std::collections::hash_map::RandomState]: https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html
-pub struct GenericHashSet<A, S = RandomState, P: SharedPointerKind = DefaultSharedPtr> {
+pub struct HashSet<A, S = RandomState, P: SharedPointerKind = DefaultSharedPtr> {
     hasher: S,
     root: Option<SharedPointer<Node<Value<A>, P>, P>>,
     size: usize,
@@ -130,7 +123,7 @@ where
     }
 }
 
-impl<A, S, P> GenericHashSet<A, S, P>
+impl<A, S, P> HashSet<A, S, P>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher + Default + Clone,
@@ -144,26 +137,48 @@ where
     /// # #[macro_use] extern crate imbl;
     /// # use imbl::hashset::HashSet;
     /// # use std::sync::Arc;
-    /// let set = HashSet::unit(123);
+    /// let set = HashSet::<_>::unit(123);
     /// assert!(set.contains(&123));
     /// ```
     #[inline]
     #[must_use]
     pub fn unit(a: A) -> Self {
-        GenericHashSet::new().update(a)
+        HashSet::with_hasher_and_kind(Default::default()).update(a)
     }
 }
 
-impl<A, S, P: SharedPointerKind> GenericHashSet<A, S, P> {
-    /// Construct an empty set.
+impl<K> HashSet<K, RandomState, DefaultSharedPtr> {
+    /// Construct an empty set using the default hasher and shared kind
+    #[inline]
     #[must_use]
-    pub fn new() -> Self
-    where
-        S: Default,
-    {
-        Self::default()
+    pub fn new() -> Self {
+        Default::default()
     }
+}
 
+impl<K, P: SharedPointerKind> HashSet<K, RandomState, P> {
+    /// Construct an empty set using a custom shared kind
+    #[inline]
+    #[must_use]
+    pub fn with_kind() -> Self {
+        Default::default()
+    }
+}
+
+impl<K, S> HashSet<K, S, DefaultSharedPtr> {
+    /// Construct an empty hash set using the provided hasher.
+    #[inline]
+    #[must_use]
+    pub fn with_hasher(hasher: S) -> Self {
+        HashSet {
+            size: 0,
+            root: None,
+            hasher,
+        }
+    }
+}
+
+impl<A, S, P: SharedPointerKind> HashSet<A, S, P> {
     /// Test whether a set is empty.
     ///
     /// Time: O(1)
@@ -223,8 +238,8 @@ impl<A, S, P: SharedPointerKind> GenericHashSet<A, S, P> {
     /// Construct an empty hash set using the provided hasher.
     #[inline]
     #[must_use]
-    pub fn with_hasher(hasher: S) -> Self {
-        GenericHashSet {
+    pub fn with_hasher_and_kind(hasher: S) -> Self {
+        HashSet {
             size: 0,
             root: None,
             hasher,
@@ -242,12 +257,12 @@ impl<A, S, P: SharedPointerKind> GenericHashSet<A, S, P> {
     /// Construct an empty hash set using the same hasher as the current hash set.
     #[inline]
     #[must_use]
-    pub fn new_from<A2>(&self) -> GenericHashSet<A2, S, P>
+    pub fn new_from<A2>(&self) -> HashSet<A2, S, P>
     where
         A2: Hash + Eq + Clone,
         S: Clone,
     {
-        GenericHashSet {
+        HashSet {
             size: 0,
             root: None,
             hasher: self.hasher.clone(),
@@ -290,16 +305,13 @@ impl<A, S, P: SharedPointerKind> GenericHashSet<A, S, P> {
     }
 }
 
-impl<A, S, P> GenericHashSet<A, S, P>
+impl<A, S, P> HashSet<A, S, P>
 where
     A: Hash + Eq,
     S: BuildHasher,
     P: SharedPointerKind,
 {
-    fn test_eq<S2: BuildHasher, P2: SharedPointerKind>(
-        &self,
-        other: &GenericHashSet<A, S2, P2>,
-    ) -> bool {
+    fn test_eq<S2: BuildHasher, P2: SharedPointerKind>(&self, other: &HashSet<A, S2, P2>) -> bool {
         if self.len() != other.len() {
             return false;
         }
@@ -360,7 +372,7 @@ where
     }
 }
 
-impl<A, S, P> GenericHashSet<A, S, P>
+impl<A, S, P> HashSet<A, S, P>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher + Clone,
@@ -612,7 +624,7 @@ where
 
 // Core traits
 
-impl<A, S, P: SharedPointerKind> Clone for GenericHashSet<A, S, P>
+impl<A, S, P: SharedPointerKind> Clone for HashSet<A, S, P>
 where
     A: Clone,
     S: Clone,
@@ -623,7 +635,7 @@ where
     /// Time: O(1)
     #[inline]
     fn clone(&self) -> Self {
-        GenericHashSet {
+        HashSet {
             hasher: self.hasher.clone(),
             root: self.root.clone(),
             size: self.size,
@@ -631,7 +643,7 @@ where
     }
 }
 
-impl<A, S1, P1, S2, P2> PartialEq<GenericHashSet<A, S2, P2>> for GenericHashSet<A, S1, P1>
+impl<A, S1, P1, S2, P2> PartialEq<HashSet<A, S2, P2>> for HashSet<A, S1, P1>
 where
     A: Hash + Eq,
     S1: BuildHasher,
@@ -639,12 +651,12 @@ where
     P1: SharedPointerKind,
     P2: SharedPointerKind,
 {
-    fn eq(&self, other: &GenericHashSet<A, S2, P2>) -> bool {
+    fn eq(&self, other: &HashSet<A, S2, P2>) -> bool {
         self.test_eq(other)
     }
 }
 
-impl<A, S, P> Eq for GenericHashSet<A, S, P>
+impl<A, S, P> Eq for HashSet<A, S, P>
 where
     A: Hash + Eq,
     S: BuildHasher,
@@ -652,13 +664,13 @@ where
 {
 }
 
-impl<A, S, P> Default for GenericHashSet<A, S, P>
+impl<A, S, P> Default for HashSet<A, S, P>
 where
     S: Default,
     P: SharedPointerKind,
 {
     fn default() -> Self {
-        GenericHashSet {
+        HashSet {
             hasher: Default::default(),
             root: None,
             size: 0,
@@ -666,59 +678,59 @@ where
     }
 }
 
-impl<A, S, P> Add for GenericHashSet<A, S, P>
+impl<A, S, P> Add for HashSet<A, S, P>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher + Clone,
     P: SharedPointerKind,
 {
-    type Output = GenericHashSet<A, S, P>;
+    type Output = HashSet<A, S, P>;
 
     fn add(self, other: Self) -> Self::Output {
         self.union(other)
     }
 }
 
-impl<A, S, P> Mul for GenericHashSet<A, S, P>
+impl<A, S, P> Mul for HashSet<A, S, P>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher + Clone,
     P: SharedPointerKind,
 {
-    type Output = GenericHashSet<A, S, P>;
+    type Output = HashSet<A, S, P>;
 
     fn mul(self, other: Self) -> Self::Output {
         self.intersection(other)
     }
 }
 
-impl<A, S, P> Add for &GenericHashSet<A, S, P>
+impl<A, S, P> Add for &HashSet<A, S, P>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher + Clone,
     P: SharedPointerKind,
 {
-    type Output = GenericHashSet<A, S, P>;
+    type Output = HashSet<A, S, P>;
 
     fn add(self, other: Self) -> Self::Output {
         self.clone().union(other.clone())
     }
 }
 
-impl<A, S, P> Mul for &GenericHashSet<A, S, P>
+impl<A, S, P> Mul for &HashSet<A, S, P>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher + Clone,
     P: SharedPointerKind,
 {
-    type Output = GenericHashSet<A, S, P>;
+    type Output = HashSet<A, S, P>;
 
     fn mul(self, other: Self) -> Self::Output {
         self.clone().intersection(other.clone())
     }
 }
 
-impl<A, S, P: SharedPointerKind> Sum for GenericHashSet<A, S, P>
+impl<A, S, P: SharedPointerKind> Sum for HashSet<A, S, P>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher + Default + Clone,
@@ -732,7 +744,7 @@ where
     }
 }
 
-impl<A, S, R, P: SharedPointerKind> Extend<R> for GenericHashSet<A, S, P>
+impl<A, S, R, P: SharedPointerKind> Extend<R> for HashSet<A, S, P>
 where
     A: Hash + Eq + Clone + From<R>,
     S: BuildHasher + Clone,
@@ -747,7 +759,7 @@ where
     }
 }
 
-impl<A, S, P> Debug for GenericHashSet<A, S, P>
+impl<A, S, P> Debug for HashSet<A, S, P>
 where
     A: Hash + Eq + Debug,
     S: BuildHasher,
@@ -835,7 +847,7 @@ where
 
 // Iterator conversions
 
-impl<A, RA, S, P> FromIterator<RA> for GenericHashSet<A, S, P>
+impl<A, RA, S, P> FromIterator<RA> for HashSet<A, S, P>
 where
     A: Hash + Eq + Clone + From<RA>,
     S: BuildHasher + Default + Clone,
@@ -853,7 +865,7 @@ where
     }
 }
 
-impl<'a, A, S, P> IntoIterator for &'a GenericHashSet<A, S, P>
+impl<'a, A, S, P> IntoIterator for &'a HashSet<A, S, P>
 where
     A: Hash + Eq,
     S: BuildHasher,
@@ -867,7 +879,7 @@ where
     }
 }
 
-impl<A, S, P> IntoIterator for GenericHashSet<A, S, P>
+impl<A, S, P> IntoIterator for HashSet<A, S, P>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher,
@@ -885,7 +897,7 @@ where
 
 // Conversions
 
-impl<A, OA, SA, SB, P1, P2> From<&GenericHashSet<&A, SA, P1>> for GenericHashSet<OA, SB, P2>
+impl<A, OA, SA, SB, P1, P2> From<&HashSet<&A, SA, P1>> for HashSet<OA, SB, P2>
 where
     A: ToOwned<Owned = OA> + Hash + Equivalent<A> + ?Sized,
     OA: Hash + Eq + Clone,
@@ -894,12 +906,12 @@ where
     P1: SharedPointerKind,
     P2: SharedPointerKind,
 {
-    fn from(set: &GenericHashSet<&A, SA, P1>) -> Self {
+    fn from(set: &HashSet<&A, SA, P1>) -> Self {
         set.iter().map(|a| (*a).to_owned()).collect()
     }
 }
 
-impl<A, S, const N: usize, P> From<[A; N]> for GenericHashSet<A, S, P>
+impl<A, S, const N: usize, P> From<[A; N]> for HashSet<A, S, P>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher + Default + Clone,
@@ -910,7 +922,7 @@ where
     }
 }
 
-impl<'a, A, S, P> From<&'a [A]> for GenericHashSet<A, S, P>
+impl<'a, A, S, P> From<&'a [A]> for HashSet<A, S, P>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher + Default + Clone,
@@ -921,7 +933,7 @@ where
     }
 }
 
-impl<A, S, P> From<Vec<A>> for GenericHashSet<A, S, P>
+impl<A, S, P> From<Vec<A>> for HashSet<A, S, P>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher + Default + Clone,
@@ -932,7 +944,7 @@ where
     }
 }
 
-impl<A, S, P> From<&Vec<A>> for GenericHashSet<A, S, P>
+impl<A, S, P> From<&Vec<A>> for HashSet<A, S, P>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher + Default + Clone,
@@ -943,33 +955,31 @@ where
     }
 }
 
-impl<A, S, P1, P2, const CHUNK_SIZE: usize> From<GenericVector<A, P2, CHUNK_SIZE>>
-    for GenericHashSet<A, S, P1>
+impl<A, S, P1, P2, const CHUNK_SIZE: usize> From<Vector<A, P2, CHUNK_SIZE>> for HashSet<A, S, P1>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher + Default + Clone,
     P1: SharedPointerKind,
     P2: SharedPointerKind,
 {
-    fn from(vector: GenericVector<A, P2, CHUNK_SIZE>) -> Self {
+    fn from(vector: Vector<A, P2, CHUNK_SIZE>) -> Self {
         vector.into_iter().collect()
     }
 }
 
-impl<A, S, P1, P2, const CHUNK_SIZE: usize> From<&GenericVector<A, P2, CHUNK_SIZE>>
-    for GenericHashSet<A, S, P1>
+impl<A, S, P1, P2, const CHUNK_SIZE: usize> From<&Vector<A, P2, CHUNK_SIZE>> for HashSet<A, S, P1>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher + Default + Clone,
     P1: SharedPointerKind,
     P2: SharedPointerKind,
 {
-    fn from(vector: &GenericVector<A, P2, CHUNK_SIZE>) -> Self {
+    fn from(vector: &Vector<A, P2, CHUNK_SIZE>) -> Self {
         vector.iter().cloned().collect()
     }
 }
 
-impl<A, S, P> From<collections::HashSet<A>> for GenericHashSet<A, S, P>
+impl<A, S, P> From<collections::HashSet<A>> for HashSet<A, S, P>
 where
     A: Eq + Hash + Clone,
     S: BuildHasher + Default + Clone,
@@ -980,7 +990,7 @@ where
     }
 }
 
-impl<A, S, P> From<&collections::HashSet<A>> for GenericHashSet<A, S, P>
+impl<A, S, P> From<&collections::HashSet<A>> for HashSet<A, S, P>
 where
     A: Eq + Hash + Clone,
     S: BuildHasher + Default + Clone,
@@ -991,7 +1001,7 @@ where
     }
 }
 
-impl<A, S, P> From<&BTreeSet<A>> for GenericHashSet<A, S, P>
+impl<A, S, P> From<&BTreeSet<A>> for HashSet<A, S, P>
 where
     A: Hash + Eq + Clone,
     S: BuildHasher + Default + Clone,
@@ -1002,26 +1012,26 @@ where
     }
 }
 
-impl<A, S, P1, P2> From<GenericOrdSet<A, P2>> for GenericHashSet<A, S, P1>
+impl<A, S, P1, P2> From<OrdSet<A, P2>> for HashSet<A, S, P1>
 where
     A: Ord + Hash + Eq + Clone,
     S: BuildHasher + Default + Clone,
     P1: SharedPointerKind,
     P2: SharedPointerKind,
 {
-    fn from(ordset: GenericOrdSet<A, P2>) -> Self {
+    fn from(ordset: OrdSet<A, P2>) -> Self {
         ordset.into_iter().collect()
     }
 }
 
-impl<A, S, P1, P2> From<&GenericOrdSet<A, P2>> for GenericHashSet<A, S, P1>
+impl<A, S, P1, P2> From<&OrdSet<A, P2>> for HashSet<A, S, P1>
 where
     A: Ord + Hash + Eq + Clone,
     S: BuildHasher + Default + Clone,
     P1: SharedPointerKind,
     P2: SharedPointerKind,
 {
-    fn from(ordset: &GenericOrdSet<A, P2>) -> Self {
+    fn from(ordset: &OrdSet<A, P2>) -> Self {
         ordset.into_iter().cloned().collect()
     }
 }
@@ -1053,7 +1063,7 @@ mod test {
 
     #[test]
     fn insert_failing() {
-        let mut set: GenericHashSet<i16, BuildHasherDefault<LolHasher>, DefaultSharedPtr> =
+        let mut set: HashSet<i16, BuildHasherDefault<LolHasher>, DefaultSharedPtr> =
             Default::default();
         set.insert(14658);
         assert_eq!(1, set.len());
@@ -1088,8 +1098,8 @@ mod test {
             lhs.sort_unstable();
 
             let hasher = MetroHashBuilder::new(i);
-            let mut iset: GenericHashSet<_, MetroHashBuilder, DefaultSharedPtr> =
-                GenericHashSet::with_hasher(hasher);
+            let mut iset: HashSet<_, MetroHashBuilder, DefaultSharedPtr> =
+                HashSet::with_hasher(hasher);
             for &i in &lhs {
                 iset.insert(i);
             }

--- a/src/hash/set.rs
+++ b/src/hash/set.rs
@@ -31,10 +31,10 @@ use std::ops::{Add, Deref, Mul};
 
 use archery::{SharedPointer, SharedPointerKind};
 
-use crate::nodes::hamt::{hash_key, Drain as NodeDrain, HashValue, Iter as NodeIter, Node};
+use crate::GenericVector;
+use crate::nodes::hamt::{Drain as NodeDrain, HashValue, Iter as NodeIter, Node, hash_key};
 use crate::ordset::GenericOrdSet;
 use crate::shared_ptr::DefaultSharedPtr;
-use crate::GenericVector;
 
 /// Construct a set from a sequence of values.
 ///
@@ -96,7 +96,7 @@ pub type HashSet<A> = GenericHashSet<A, RandomState, DefaultSharedPtr>;
 /// [std::cmp::Eq]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
 /// [std::hash::Hash]: https://doc.rust-lang.org/std/hash/trait.Hash.html
 /// [std::collections::hash_map::RandomState]: https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html
-pub struct GenericHashSet<A, S, P: SharedPointerKind> {
+pub struct GenericHashSet<A, S = RandomState, P: SharedPointerKind = DefaultSharedPtr> {
     hasher: S,
     root: Option<SharedPointer<Node<Value<A>, P>, P>>,
     size: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,6 +331,7 @@ mod config;
 mod nodes;
 mod sort;
 mod sync;
+pub use archery;
 
 #[macro_use]
 mod ord;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,7 @@
 //! [`Arc`](std::sync::Arc). However, `imbl` also supports `Rc` as the pointer
 //! type through the [`archery`] crate, just like `im-rc` in the original
 //! `im` crate. If you prioritise speed over thread safety, you can use
-//! [`GenericVector<T, shared_pointer::RcK>`](vector::GenericVector) that uses
+//! [`Vector<T, shared_pointer::RcK>`](vector::Vector) that uses
 //! non-threadsafe but faster `Rc`, instead of the type alias
 //! [`Vector`]. You can also create your own type alias for that.
 //!  It can be done on other types too.
@@ -369,12 +369,12 @@ pub mod quickcheck;
 
 pub mod shared_ptr;
 
-pub use crate::hashmap::{GenericHashMap, HashMap};
-pub use crate::hashset::{GenericHashSet, HashSet};
-pub use crate::ordmap::{GenericOrdMap, OrdMap};
-pub use crate::ordset::{GenericOrdSet, OrdSet};
+pub use crate::hashmap::HashMap;
+pub use crate::hashset::HashSet;
+pub use crate::ordmap::OrdMap;
+pub use crate::ordset::OrdSet;
 #[doc(inline)]
-pub use crate::vector::{GenericVector, Vector};
+pub use crate::vector::Vector;
 
 #[cfg(test)]
 mod test;

--- a/src/nodes/btree.rs
+++ b/src/nodes/btree.rs
@@ -973,11 +973,12 @@ impl<'a, K, V, P: SharedPointerKind> Iter<'a, K, V, P> {
         // Check if the cursors are exhausted by checking their leaves
         // This is valid even if the cursors are empty due to not being initialized yet.
         // If they were empty because exhaustion we would not be in this function.
-        if let (Some((fi, f)), Some((bi, b))) = (self.fwd.leaf, self.bwd.leaf) {
-            if std::ptr::eq(f, b) && fi >= bi {
-                self.exhausted = true;
-                return fi == bi && other_side_yielded;
-            }
+        if let (Some((fi, f)), Some((bi, b))) = (self.fwd.leaf, self.bwd.leaf)
+            && std::ptr::eq(f, b)
+            && fi >= bi
+        {
+            self.exhausted = true;
+            return fi == bi && other_side_yielded;
         }
         false
     }
@@ -1192,22 +1193,22 @@ impl<'a, K, V, P: SharedPointerKind> Cursor<'a, K, V, P> {
             let mut skipped_any = false;
             debug_assert!(self.leaf.is_some());
             debug_assert!(other.leaf.is_some());
-            if let (Some(this), Some(that)) = (self.leaf, other.leaf) {
-                if std::ptr::eq(this.1, that.1) {
-                    self.leaf = None;
-                    other.leaf = None;
-                    skipped_any = true;
-                    let shared_levels = self
-                        .stack
-                        .iter()
-                        .rev()
-                        .zip(other.stack.iter().rev())
-                        .take_while(|(this, that)| std::ptr::eq(this.1, that.1))
-                        .count();
-                    if shared_levels != 0 {
-                        self.stack.drain(self.stack.len() - shared_levels..);
-                        other.stack.drain(other.stack.len() - shared_levels..);
-                    }
+            if let (Some(this), Some(that)) = (self.leaf, other.leaf)
+                && std::ptr::eq(this.1, that.1)
+            {
+                self.leaf = None;
+                other.leaf = None;
+                skipped_any = true;
+                let shared_levels = self
+                    .stack
+                    .iter()
+                    .rev()
+                    .zip(other.stack.iter().rev())
+                    .take_while(|(this, that)| std::ptr::eq(this.1, that.1))
+                    .count();
+                if shared_levels != 0 {
+                    self.stack.drain(self.stack.len() - shared_levels..);
+                    other.stack.drain(other.stack.len() - shared_levels..);
                 }
             }
             self.next();

--- a/src/nodes/hamt.rs
+++ b/src/nodes/hamt.rs
@@ -739,6 +739,7 @@ impl<A, P: SharedPointerKind> Node<A, P> {
 /// An allocation-free stack for iterators.
 type InlineStack<T> = InlineArray<T, (usize, [T; ITER_STACK_CAPACITY])>;
 
+#[allow(clippy::enum_variant_names)]
 enum IterItem<'a, A, P: SharedPointerKind> {
     SmallSimdNode(ChunkIter<'a, (A, HashBits), SMALL_NODE_WIDTH>),
     LargeSimdNode(ChunkIter<'a, (A, HashBits), HASH_WIDTH>),
@@ -859,7 +860,7 @@ impl<'a, A, P: SharedPointerKind> ExactSizeIterator for Iter<'a, A, P> where A: 
 impl<'a, A, P: SharedPointerKind> FusedIterator for Iter<'a, A, P> where A: 'a {}
 
 // Mut ref iterator
-
+#[allow(clippy::enum_variant_names)]
 enum IterMutItem<'a, A, P: SharedPointerKind> {
     SmallSimdNode(ChunkIterMut<'a, (A, HashBits), SMALL_NODE_WIDTH>),
     LargeSimdNode(ChunkIterMut<'a, (A, HashBits), HASH_WIDTH>),

--- a/src/nodes/hamt.rs
+++ b/src/nodes/hamt.rs
@@ -52,7 +52,7 @@ fn group_find_empty(control: &SimdGroup) -> Option<usize> {
 
 #[inline]
 fn group_find(control: &SimdGroup, value: u8) -> GroupBitmap {
-    let mask = control.cmp_eq(SimdGroup::splat(value)).move_mask();
+    let mask = control.simd_eq(SimdGroup::splat(value)).to_bitmask();
     GroupBitmap::from_value(mask as _)
 }
 

--- a/src/nodes/hamt.rs
+++ b/src/nodes/hamt.rs
@@ -213,7 +213,7 @@ where
 
         while let Some(offset) = bitmap.first_index() {
             let index = group * GROUP_WIDTH + offset;
-            let (ref value, value_hash) = self.data.get(index).unwrap();
+            let (value, value_hash) = self.data.get(index).unwrap();
             if hash_may_eq::<A>(hash, *value_hash) && key.equivalent(value.extract_key()) {
                 return Some(value);
             }
@@ -236,7 +236,7 @@ where
             let index = group * GROUP_WIDTH + offset;
             #[allow(unsafe_code)]
             let this = unsafe { &mut *this };
-            let (ref mut value, value_hash) = this.data.get_mut(index).unwrap();
+            let (value, value_hash) = this.data.get_mut(index).unwrap();
             if hash_may_eq::<A>(hash, *value_hash) && key.equivalent(value.extract_key()) {
                 return Some(value);
             }
@@ -254,7 +254,7 @@ where
 
         while let Some(offset) = bitmap.first_index() {
             let index = group * GROUP_WIDTH + offset;
-            let (ref value, value_hash) = self.data.get(index).unwrap();
+            let (value, value_hash) = self.data.get(index).unwrap();
             if hash_may_eq::<A>(hash, *value_hash) && key.equivalent(value.extract_key()) {
                 let mut ctrl_array = self.control[group].to_array();
                 ctrl_array[offset] = 0;
@@ -414,12 +414,12 @@ impl<A: HashValue, P: SharedPointerKind> HamtNode<A, P> {
             // This is less relevant in other code paths that may include
             // atomics, memory allocation (e.g. insert, remove) etc..
             match entry {
-                Entry::HamtNode(ref child) => {
+                Entry::HamtNode(child) => {
                     node = child;
                     shift += HASH_SHIFT;
                     continue;
                 }
-                Entry::Value(ref value, value_hash) => {
+                Entry::Value(value, value_hash) => {
                     return if hash_may_eq::<A>(hash, *value_hash)
                         && key.equivalent(value.extract_key())
                     {
@@ -443,9 +443,9 @@ impl<A: HashValue, P: SharedPointerKind> HamtNode<A, P> {
         Q: Equivalent<A::Key> + ?Sized,
     {
         match entry {
-            Entry::SmallSimdNode(ref small) => small.get(hash, key),
-            Entry::LargeSimdNode(ref large) => large.get(hash, key),
-            Entry::Collision(ref coll) => coll.get(key),
+            Entry::SmallSimdNode(small) => small.get(hash, key),
+            Entry::LargeSimdNode(large) => large.get(hash, key),
+            Entry::Collision(coll) => coll.get(key),
             _ => unreachable!(),
         }
     }
@@ -457,25 +457,23 @@ impl<A: HashValue, P: SharedPointerKind> HamtNode<A, P> {
     {
         let index = Self::mask(hash, shift) as usize;
         match self.data.get_mut(index) {
-            Some(Entry::HamtNode(ref mut child_ref)) => {
+            Some(Entry::HamtNode(child_ref)) => {
                 SharedPointer::make_mut(child_ref).get_mut(hash, shift + HASH_SHIFT, key)
             }
-            Some(Entry::SmallSimdNode(ref mut small_ref)) => {
+            Some(Entry::SmallSimdNode(small_ref)) => {
                 SharedPointer::make_mut(small_ref).get_mut(hash, key)
             }
-            Some(Entry::LargeSimdNode(ref mut large_ref)) => {
+            Some(Entry::LargeSimdNode(large_ref)) => {
                 SharedPointer::make_mut(large_ref).get_mut(hash, key)
             }
-            Some(Entry::Value(ref mut value, value_hash)) => {
+            Some(Entry::Value(value, value_hash)) => {
                 if hash_may_eq::<A>(hash, *value_hash) && key.equivalent(value.extract_key()) {
                     Some(value)
                 } else {
                     None
                 }
             }
-            Some(Entry::Collision(ref mut coll_ref)) => {
-                SharedPointer::make_mut(coll_ref).get_mut(key)
-            }
+            Some(Entry::Collision(coll_ref)) => SharedPointer::make_mut(coll_ref).get_mut(key),
             None => None,
         }
     }

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -7,8 +7,7 @@ pub(crate) mod hamt;
 pub(crate) mod rrb;
 
 pub(crate) mod chunk {
-    pub(crate) use crate::config::VECTOR_CHUNK_SIZE as CHUNK_SIZE;
     use imbl_sized_chunks as sc;
 
-    pub(crate) type Chunk<A> = sc::sized_chunk::Chunk<A, CHUNK_SIZE>;
+    pub(crate) type Chunk<A, const CHUNK_SIZE: usize> = sc::sized_chunk::Chunk<A, CHUNK_SIZE>;
 }

--- a/src/nodes/rrb.rs
+++ b/src/nodes/rrb.rs
@@ -738,12 +738,12 @@ impl<A: Clone, P: SharedPointerKind, const NODE_SIZE: usize> Node<A, P, NODE_SIZ
             } else if is_full {
                 PushResult::Full(chunk, num_drained)
             } else {
-                if side == Left && chunk.len() < NODE_SIZE {
-                    if let Entry::Nodes(ref mut size, _) = self.children {
-                        if let Size::Size(value) = *size {
-                            *size = Size::table_from_size(level, value);
-                        }
-                    }
+                if side == Left
+                    && chunk.len() < NODE_SIZE
+                    && let Entry::Nodes(ref mut size, _) = self.children
+                    && let Size::Size(value) = *size
+                {
+                    *size = Size::table_from_size(level, value);
                 }
                 self.push_size(side, level, chunk.len());
                 self.push_child_node(side, Node::from_chunk(0, chunk));
@@ -794,12 +794,12 @@ impl<A: Clone, P: SharedPointerKind, const NODE_SIZE: usize> Node<A, P, NODE_SIZ
                     PushResult::Done
                 }
                 Some(child) => {
-                    if side == Left && chunk_size < NODE_SIZE {
-                        if let Entry::Nodes(ref mut size, _) = self.children {
-                            if let Size::Size(value) = *size {
-                                *size = Size::table_from_size(level, value);
-                            }
-                        }
+                    if side == Left
+                        && chunk_size < NODE_SIZE
+                        && let Entry::Nodes(ref mut size, _) = self.children
+                        && let Size::Size(value) = *size
+                    {
+                        *size = Size::table_from_size(level, value);
                     }
                     self.push_size(side, level, child.len());
                     self.push_child_node(side, child);
@@ -1288,18 +1288,18 @@ pub(crate) fn fold_subsequence<T: Clone, P: SharedPointerKind, const NODE_SIZE: 
     match (&input.children, prev_out) {
         (Entry::Values(xs), y) => {
             if let FoldSeqStore::Values(total, ys) = y
-                && SharedPointer::ptr_eq(&xs, &ys)
+                && SharedPointer::ptr_eq(xs, &ys)
             {
                 FoldSeqStore::Values(total, ys)
             } else if xs.is_empty() {
                 FoldSeqStore::Empty
             } else {
-                let result = binary_fold_inner::<T>(&xs, f);
+                let result = binary_fold_inner::<T>(xs, f);
                 FoldSeqStore::Values(result, xs.clone())
             }
         }
         (Entry::Nodes(_, children), FoldSeqStore::Nodes(total, old_children, total_children)) => {
-            if SharedPointer::ptr_eq(&children, &old_children) {
+            if SharedPointer::ptr_eq(children, &old_children) {
                 FoldSeqStore::Nodes(total, old_children, total_children)
             } else if children.is_empty() {
                 FoldSeqStore::Empty

--- a/src/ord/map.rs
+++ b/src/ord/map.rs
@@ -1548,7 +1548,7 @@ where
         F: FnOnce(&mut V),
     {
         match &mut self {
-            Entry::Occupied(ref mut entry) => f(entry.get_mut()),
+            Entry::Occupied(entry) => f(entry.get_mut()),
             Entry::Vacant(_) => (),
         }
         self
@@ -2305,12 +2305,12 @@ where
 }
 
 impl<
-        K: Ord + Hash + Eq + Clone,
-        V: Clone,
-        S: BuildHasher + Clone,
-        P1: SharedPointerKind,
-        P2: SharedPointerKind,
-    > From<GenericHashMap<K, V, S, P2>> for GenericOrdMap<K, V, P1>
+    K: Ord + Hash + Eq + Clone,
+    V: Clone,
+    S: BuildHasher + Clone,
+    P1: SharedPointerKind,
+    P2: SharedPointerKind,
+> From<GenericHashMap<K, V, S, P2>> for GenericOrdMap<K, V, P1>
 {
     fn from(m: GenericHashMap<K, V, S, P2>) -> Self {
         m.into_iter().collect()
@@ -2318,13 +2318,13 @@ impl<
 }
 
 impl<
-        'a,
-        K: Ord + Hash + Eq + Clone,
-        V: Clone,
-        S: BuildHasher + Clone,
-        P1: SharedPointerKind,
-        P2: SharedPointerKind,
-    > From<&'a GenericHashMap<K, V, S, P2>> for GenericOrdMap<K, V, P1>
+    'a,
+    K: Ord + Hash + Eq + Clone,
+    V: Clone,
+    S: BuildHasher + Clone,
+    P1: SharedPointerKind,
+    P2: SharedPointerKind,
+> From<&'a GenericHashMap<K, V, S, P2>> for GenericOrdMap<K, V, P1>
 {
     fn from(m: &'a GenericHashMap<K, V, S, P2>) -> Self {
         m.iter().map(|(k, v)| (k.clone(), v.clone())).collect()

--- a/src/ord/map.rs
+++ b/src/ord/map.rs
@@ -744,15 +744,14 @@ where
     {
         let root = self.root.as_mut()?;
         let mut removed = None;
-        if root.remove(k, &mut removed) {
-            if let Node::Branch(branch) = root {
-                if let Some(child) = SharedPointer::make_mut(branch).pop_single_child() {
-                    self.root = Some(child);
-                }
-            }
-            // Note that even if the root leaf is empty, we don't
-            // drop it, but retain the allocation for future use.
+        if root.remove(k, &mut removed)
+            && let Node::Branch(branch) = root
+            && let Some(child) = SharedPointer::make_mut(branch).pop_single_child()
+        {
+            self.root = Some(child);
         }
+        // Note that even if the root leaf is empty, we don't
+        // drop it, but retain the allocation for future use.
         self.size -= removed.is_some() as usize;
         removed
     }

--- a/src/ord/map.rs
+++ b/src/ord/map.rs
@@ -29,7 +29,7 @@ use std::ops::{Add, Bound, Index, IndexMut, RangeBounds};
 use archery::{SharedPointer, SharedPointerKind};
 use equivalent::Comparable;
 
-use crate::hashmap::GenericHashMap;
+use crate::hashmap::HashMap;
 use crate::nodes::btree::{
     ConsumingIter as NodeConsumingIter, Cursor, InsertAction, Iter as NodeIter, Node,
 };
@@ -66,12 +66,6 @@ macro_rules! ordmap {
     }};
 }
 
-/// Type alias for [`GenericOrdMap`] that uses [`DefaultSharedPtr`] as the pointer type.
-///
-/// [GenericOrdMap]: ./struct.GenericOrdMap.html
-/// [DefaultSharedPtr]: ../shared_ptr/type.DefaultSharedPtr.html
-pub type OrdMap<K, V> = GenericOrdMap<K, V, DefaultSharedPtr>;
-
 /// An ordered map.
 ///
 /// An immutable ordered map implemented as a B+tree [1].
@@ -86,20 +80,26 @@ pub type OrdMap<K, V> = GenericOrdMap<K, V, DefaultSharedPtr>;
 /// [1]: https://en.wikipedia.org/wiki/B%2B_tree
 /// [hashmap::HashMap]: ../hashmap/type.HashMap.html
 /// [std::cmp::Ord]: https://doc.rust-lang.org/std/cmp/trait.Ord.html
-pub struct GenericOrdMap<K, V, P: SharedPointerKind> {
+pub struct OrdMap<K, V, P: SharedPointerKind = DefaultSharedPtr> {
     size: usize,
     root: Option<Node<K, V, P>>,
 }
 
-impl<K, V, P: SharedPointerKind> GenericOrdMap<K, V, P> {
+impl<K, V> OrdMap<K, V, DefaultSharedPtr> {
     /// Construct an empty map.
     #[inline]
     #[must_use]
     pub fn new() -> Self {
-        GenericOrdMap {
-            size: 0,
-            root: None,
-        }
+        Default::default()
+    }
+}
+
+impl<K, V, P: SharedPointerKind> OrdMap<K, V, P> {
+    /// Construct an empty map with a custom shared kind
+    #[inline]
+    #[must_use]
+    pub fn with_kind() -> Self {
+        Default::default()
     }
 
     /// Construct a map with a single mapping.
@@ -206,7 +206,7 @@ impl<K, V, P: SharedPointerKind> GenericOrdMap<K, V, P> {
     }
 }
 
-impl<K, V, P> GenericOrdMap<K, V, P>
+impl<K, V, P> OrdMap<K, V, P>
 where
     K: Ord,
     P: SharedPointerKind,
@@ -447,7 +447,7 @@ where
     pub fn is_submap_by<B, RM, F, P2>(&self, other: RM, mut cmp: F) -> bool
     where
         F: FnMut(&V, &B) -> bool,
-        RM: Borrow<GenericOrdMap<K, B, P2>>,
+        RM: Borrow<OrdMap<K, B, P2>>,
         P2: SharedPointerKind,
     {
         self.iter()
@@ -466,7 +466,7 @@ where
     pub fn is_proper_submap_by<B, RM, F, P2>(&self, other: RM, cmp: F) -> bool
     where
         F: FnMut(&V, &B) -> bool,
-        RM: Borrow<GenericOrdMap<K, B, P2>>,
+        RM: Borrow<OrdMap<K, B, P2>>,
         P2: SharedPointerKind,
     {
         self.len() != other.borrow().len() && self.is_submap_by(other, cmp)
@@ -542,7 +542,7 @@ where
     }
 }
 
-impl<K, V, P> GenericOrdMap<K, V, P>
+impl<K, V, P> OrdMap<K, V, P>
 where
     K: Ord + Clone,
     V: Clone,
@@ -1296,9 +1296,9 @@ where
     #[must_use]
     pub fn intersection_with<B, C, F, P2, P3>(
         self,
-        other: GenericOrdMap<K, B, P2>,
+        other: OrdMap<K, B, P2>,
         mut f: F,
-    ) -> GenericOrdMap<K, C, P3>
+    ) -> OrdMap<K, C, P3>
     where
         B: Clone,
         C: Clone,
@@ -1331,9 +1331,9 @@ where
     #[must_use]
     pub fn intersection_with_key<B, C, F, P2, P3>(
         mut self,
-        other: GenericOrdMap<K, B, P2>,
+        other: OrdMap<K, B, P2>,
         mut f: F,
-    ) -> GenericOrdMap<K, C, P3>
+    ) -> OrdMap<K, C, P3>
     where
         B: Clone,
         C: Clone,
@@ -1341,7 +1341,7 @@ where
         P2: SharedPointerKind,
         P3: SharedPointerKind,
     {
-        let mut out = GenericOrdMap::<K, C, P3>::default();
+        let mut out = OrdMap::<K, C, P3>::default();
         for (key, right_value) in other {
             match self.remove(&key) {
                 None => (),
@@ -1380,7 +1380,7 @@ where
     {
         // TODO this is atrociously slow, got to be a better way
         self.iter().fold(
-            (GenericOrdMap::new(), None, GenericOrdMap::new()),
+            (OrdMap::with_kind(), None, OrdMap::with_kind()),
             |(l, m, r), (k, v)| match split.compare(k).reverse() {
                 Ordering::Less => (l.update(k.clone(), v.clone()), m, r),
                 Ordering::Equal => (l, Some(v.clone()), r),
@@ -1547,7 +1547,7 @@ where
     V: Clone,
     P: SharedPointerKind,
 {
-    map: &'a mut GenericOrdMap<K, V, P>,
+    map: &'a mut OrdMap<K, V, P>,
     key: K,
 }
 
@@ -1606,7 +1606,7 @@ where
     V: Clone,
     P: SharedPointerKind,
 {
-    map: &'a mut GenericOrdMap<K, V, P>,
+    map: &'a mut OrdMap<K, V, P>,
     key: K,
 }
 
@@ -1638,13 +1638,13 @@ where
 
 // Core traits
 
-impl<K, V, P: SharedPointerKind> Clone for GenericOrdMap<K, V, P> {
+impl<K, V, P: SharedPointerKind> Clone for OrdMap<K, V, P> {
     /// Clone a map.
     ///
     /// Time: O(1)
     #[inline]
     fn clone(&self) -> Self {
-        GenericOrdMap {
+        OrdMap {
             size: self.size,
             root: self.root.clone(),
         }
@@ -1652,32 +1652,32 @@ impl<K, V, P: SharedPointerKind> Clone for GenericOrdMap<K, V, P> {
 }
 
 // TODO: Support PartialEq for OrdMap that have different P
-impl<K, V, P> PartialEq for GenericOrdMap<K, V, P>
+impl<K, V, P> PartialEq for OrdMap<K, V, P>
 where
     K: Ord + PartialEq,
     V: PartialEq,
     P: SharedPointerKind,
 {
-    fn eq(&self, other: &GenericOrdMap<K, V, P>) -> bool {
+    fn eq(&self, other: &OrdMap<K, V, P>) -> bool {
         self.len() == other.len() && self.diff(other).next().is_none()
     }
 }
 
-impl<K: Ord + Eq, V: Eq, P: SharedPointerKind> Eq for GenericOrdMap<K, V, P> {}
+impl<K: Ord + Eq, V: Eq, P: SharedPointerKind> Eq for OrdMap<K, V, P> {}
 
 // TODO: Support PartialOrd for OrdMap that have different P
-impl<K, V, P> PartialOrd for GenericOrdMap<K, V, P>
+impl<K, V, P> PartialOrd for OrdMap<K, V, P>
 where
     K: Ord,
     V: PartialOrd,
     P: SharedPointerKind,
 {
-    fn partial_cmp(&self, other: &GenericOrdMap<K, V, P>) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &OrdMap<K, V, P>) -> Option<Ordering> {
         self.iter().partial_cmp(other.iter())
     }
 }
 
-impl<K, V, P> Ord for GenericOrdMap<K, V, P>
+impl<K, V, P> Ord for OrdMap<K, V, P>
 where
     K: Ord,
     V: Ord,
@@ -1688,7 +1688,7 @@ where
     }
 }
 
-impl<K, V, P> Hash for GenericOrdMap<K, V, P>
+impl<K, V, P> Hash for OrdMap<K, V, P>
 where
     K: Ord + Hash,
     V: Hash,
@@ -1704,39 +1704,42 @@ where
     }
 }
 
-impl<K, V, P: SharedPointerKind> Default for GenericOrdMap<K, V, P> {
+impl<K, V, P: SharedPointerKind> Default for OrdMap<K, V, P> {
     fn default() -> Self {
-        Self::new()
+        Self {
+            size: 0,
+            root: None,
+        }
     }
 }
 
-impl<K, V, P> Add for &GenericOrdMap<K, V, P>
+impl<K, V, P> Add for &OrdMap<K, V, P>
 where
     K: Ord + Clone,
     V: Clone,
     P: SharedPointerKind,
 {
-    type Output = GenericOrdMap<K, V, P>;
+    type Output = OrdMap<K, V, P>;
 
     fn add(self, other: Self) -> Self::Output {
         self.clone().union(other.clone())
     }
 }
 
-impl<K, V, P> Add for GenericOrdMap<K, V, P>
+impl<K, V, P> Add for OrdMap<K, V, P>
 where
     K: Ord + Clone,
     V: Clone,
     P: SharedPointerKind,
 {
-    type Output = GenericOrdMap<K, V, P>;
+    type Output = OrdMap<K, V, P>;
 
     fn add(self, other: Self) -> Self::Output {
         self.union(other)
     }
 }
 
-impl<K, V, P> Sum for GenericOrdMap<K, V, P>
+impl<K, V, P> Sum for OrdMap<K, V, P>
 where
     K: Ord + Clone,
     V: Clone,
@@ -1750,7 +1753,7 @@ where
     }
 }
 
-impl<K, V, RK, RV, P> Extend<(RK, RV)> for GenericOrdMap<K, V, P>
+impl<K, V, RK, RV, P> Extend<(RK, RV)> for OrdMap<K, V, P>
 where
     K: Ord + Clone + From<RK>,
     V: Clone + From<RV>,
@@ -1766,7 +1769,7 @@ where
     }
 }
 
-impl<Q, K, V, P: SharedPointerKind> Index<&Q> for GenericOrdMap<K, V, P>
+impl<Q, K, V, P: SharedPointerKind> Index<&Q> for OrdMap<K, V, P>
 where
     Q: Comparable<K> + ?Sized,
     K: Ord,
@@ -1781,7 +1784,7 @@ where
     }
 }
 
-impl<Q, K, V, P> IndexMut<&Q> for GenericOrdMap<K, V, P>
+impl<Q, K, V, P> IndexMut<&Q> for OrdMap<K, V, P>
 where
     Q: Comparable<K> + ?Sized,
     K: Ord + Clone,
@@ -1796,7 +1799,7 @@ where
     }
 }
 
-impl<K, V, P> Debug for GenericOrdMap<K, V, P>
+impl<K, V, P> Debug for OrdMap<K, V, P>
 where
     K: Ord + Debug,
     V: Debug,
@@ -2075,7 +2078,7 @@ where
 {
 }
 
-impl<K, V, RK, RV, P> FromIterator<(RK, RV)> for GenericOrdMap<K, V, P>
+impl<K, V, RK, RV, P> FromIterator<(RK, RV)> for OrdMap<K, V, P>
 where
     K: Ord + Clone + From<RK>,
     V: Clone + From<RV>,
@@ -2085,7 +2088,7 @@ where
     where
         T: IntoIterator<Item = (RK, RV)>,
     {
-        let mut m = GenericOrdMap::default();
+        let mut m = OrdMap::default();
         for (k, v) in i {
             m.insert(From::from(k), From::from(v));
         }
@@ -2093,7 +2096,7 @@ where
     }
 }
 
-impl<'a, K, V, P> IntoIterator for &'a GenericOrdMap<K, V, P>
+impl<'a, K, V, P> IntoIterator for &'a OrdMap<K, V, P>
 where
     K: Ord,
     P: SharedPointerKind,
@@ -2106,7 +2109,7 @@ where
     }
 }
 
-impl<K, V, P> IntoIterator for GenericOrdMap<K, V, P>
+impl<K, V, P> IntoIterator for OrdMap<K, V, P>
 where
     K: Clone,
     V: Clone,
@@ -2165,13 +2168,13 @@ where
 
 // Conversions
 
-impl<K, V, P: SharedPointerKind> AsRef<GenericOrdMap<K, V, P>> for GenericOrdMap<K, V, P> {
+impl<K, V, P: SharedPointerKind> AsRef<OrdMap<K, V, P>> for OrdMap<K, V, P> {
     fn as_ref(&self) -> &Self {
         self
     }
 }
 
-impl<K, V, OK, OV, P1, P2> From<&GenericOrdMap<&K, &V, P2>> for GenericOrdMap<OK, OV, P1>
+impl<K, V, OK, OV, P1, P2> From<&OrdMap<&K, &V, P2>> for OrdMap<OK, OV, P1>
 where
     K: Ord + ToOwned<Owned = OK> + ?Sized,
     V: ToOwned<Owned = OV> + ?Sized,
@@ -2180,14 +2183,14 @@ where
     P1: SharedPointerKind,
     P2: SharedPointerKind,
 {
-    fn from(m: &GenericOrdMap<&K, &V, P2>) -> Self {
+    fn from(m: &OrdMap<&K, &V, P2>) -> Self {
         m.iter()
             .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
             .collect()
     }
 }
 
-impl<'a, K, V, RK, RV, OK, OV, P> From<&'a [(RK, RV)]> for GenericOrdMap<K, V, P>
+impl<'a, K, V, RK, RV, OK, OV, P> From<&'a [(RK, RV)]> for OrdMap<K, V, P>
 where
     K: Ord + Clone + From<OK>,
     V: Clone + From<OV>,
@@ -2196,25 +2199,25 @@ where
     RV: ToOwned<Owned = OV>,
     P: SharedPointerKind,
 {
-    fn from(m: &'a [(RK, RV)]) -> GenericOrdMap<K, V, P> {
+    fn from(m: &'a [(RK, RV)]) -> OrdMap<K, V, P> {
         m.iter()
             .map(|(k, v)| (k.to_owned(), v.to_owned()))
             .collect()
     }
 }
 
-impl<K, V, RK, RV, P> From<Vec<(RK, RV)>> for GenericOrdMap<K, V, P>
+impl<K, V, RK, RV, P> From<Vec<(RK, RV)>> for OrdMap<K, V, P>
 where
     K: Ord + Clone + From<RK>,
     V: Clone + From<RV>,
     P: SharedPointerKind,
 {
-    fn from(m: Vec<(RK, RV)>) -> GenericOrdMap<K, V, P> {
+    fn from(m: Vec<(RK, RV)>) -> OrdMap<K, V, P> {
         m.into_iter().collect()
     }
 }
 
-impl<'a, K, V, RK, RV, OK, OV, P> From<&'a Vec<(RK, RV)>> for GenericOrdMap<K, V, P>
+impl<'a, K, V, RK, RV, OK, OV, P> From<&'a Vec<(RK, RV)>> for OrdMap<K, V, P>
 where
     K: Ord + Clone + From<OK>,
     V: Clone + From<OV>,
@@ -2223,26 +2226,26 @@ where
     RV: ToOwned<Owned = OV>,
     P: SharedPointerKind,
 {
-    fn from(m: &'a Vec<(RK, RV)>) -> GenericOrdMap<K, V, P> {
+    fn from(m: &'a Vec<(RK, RV)>) -> OrdMap<K, V, P> {
         m.iter()
             .map(|(k, v)| (k.to_owned(), v.to_owned()))
             .collect()
     }
 }
 
-impl<K, V, RK, RV, P> From<collections::HashMap<RK, RV>> for GenericOrdMap<K, V, P>
+impl<K, V, RK, RV, P> From<collections::HashMap<RK, RV>> for OrdMap<K, V, P>
 where
     K: Ord + Clone + From<RK>,
     V: Clone + From<RV>,
     P: SharedPointerKind,
     RK: Eq + Hash,
 {
-    fn from(m: collections::HashMap<RK, RV>) -> GenericOrdMap<K, V, P> {
+    fn from(m: collections::HashMap<RK, RV>) -> OrdMap<K, V, P> {
         m.into_iter().collect()
     }
 }
 
-impl<'a, K, V, OK, OV, RK, RV, P> From<&'a collections::HashMap<RK, RV>> for GenericOrdMap<K, V, P>
+impl<'a, K, V, OK, OV, RK, RV, P> From<&'a collections::HashMap<RK, RV>> for OrdMap<K, V, P>
 where
     K: Ord + Clone + From<OK>,
     V: Clone + From<OV>,
@@ -2251,25 +2254,25 @@ where
     RV: ToOwned<Owned = OV>,
     P: SharedPointerKind,
 {
-    fn from(m: &'a collections::HashMap<RK, RV>) -> GenericOrdMap<K, V, P> {
+    fn from(m: &'a collections::HashMap<RK, RV>) -> OrdMap<K, V, P> {
         m.iter()
             .map(|(k, v)| (k.to_owned(), v.to_owned()))
             .collect()
     }
 }
 
-impl<K, V, RK, RV, P> From<collections::BTreeMap<RK, RV>> for GenericOrdMap<K, V, P>
+impl<K, V, RK, RV, P> From<collections::BTreeMap<RK, RV>> for OrdMap<K, V, P>
 where
     K: Ord + Clone + From<RK>,
     V: Clone + From<RV>,
     P: SharedPointerKind,
 {
-    fn from(m: collections::BTreeMap<RK, RV>) -> GenericOrdMap<K, V, P> {
+    fn from(m: collections::BTreeMap<RK, RV>) -> OrdMap<K, V, P> {
         m.into_iter().collect()
     }
 }
 
-impl<'a, K, V, RK, RV, OK, OV, P> From<&'a collections::BTreeMap<RK, RV>> for GenericOrdMap<K, V, P>
+impl<'a, K, V, RK, RV, OK, OV, P> From<&'a collections::BTreeMap<RK, RV>> for OrdMap<K, V, P>
 where
     K: Ord + Clone + From<OK>,
     V: Clone + From<OV>,
@@ -2278,14 +2281,14 @@ where
     RV: ToOwned<Owned = OV>,
     P: SharedPointerKind,
 {
-    fn from(m: &'a collections::BTreeMap<RK, RV>) -> GenericOrdMap<K, V, P> {
+    fn from(m: &'a collections::BTreeMap<RK, RV>) -> OrdMap<K, V, P> {
         m.iter()
             .map(|(k, v)| (k.to_owned(), v.to_owned()))
             .collect()
     }
 }
 
-impl<K, V, S, P1, P2> From<GenericHashMap<K, V, S, P2>> for GenericOrdMap<K, V, P1>
+impl<K, V, S, P1, P2> From<HashMap<K, V, S, P2>> for OrdMap<K, V, P1>
 where
     K: Ord + Hash + Eq + Clone,
     V: Clone,
@@ -2293,12 +2296,12 @@ where
     P1: SharedPointerKind,
     P2: SharedPointerKind,
 {
-    fn from(m: GenericHashMap<K, V, S, P2>) -> Self {
+    fn from(m: HashMap<K, V, S, P2>) -> Self {
         m.into_iter().collect()
     }
 }
 
-impl<'a, K, V, S, P1, P2> From<&'a GenericHashMap<K, V, S, P2>> for GenericOrdMap<K, V, P1>
+impl<'a, K, V, S, P1, P2> From<&'a HashMap<K, V, S, P2>> for OrdMap<K, V, P1>
 where
     K: Ord + Hash + Eq + Clone,
     V: Clone,
@@ -2306,7 +2309,7 @@ where
     P1: SharedPointerKind,
     P2: SharedPointerKind,
 {
-    fn from(m: &'a GenericHashMap<K, V, S, P2>) -> Self {
+    fn from(m: &'a HashMap<K, V, S, P2>) -> Self {
         m.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
     }
 }
@@ -2631,8 +2634,8 @@ mod test {
     }
 
     fn expected_diff<'a, K, V, P>(
-        a: &'a GenericOrdMap<K, V, P>,
-        b: &'a GenericOrdMap<K, V, P>,
+        a: &'a OrdMap<K, V, P>,
+        b: &'a OrdMap<K, V, P>,
     ) -> Vec<DiffItem<'a, 'a, K, V>>
     where
         K: Ord + Clone,
@@ -2843,7 +2846,7 @@ mod test {
             index_rand in usize::ANY
         ) {
             let index = *input.keys().nth(index_rand % input.len()).unwrap();
-            let map1 = OrdMap::from_iter(input.clone());
+            let map1 = OrdMap::<i16, i16>::from_iter(input.clone());
             let (val, map2): (i16, _) = map1.extract(&index).unwrap();
             let map3 = map2.update(index, val);
             for key in map2.keys() {

--- a/src/ord/set.rs
+++ b/src/ord/set.rs
@@ -7,11 +7,11 @@
 //! An immutable ordered set implemented as a [B+tree] [1].
 //!
 //! Most operations on this type of set are O(log n). A
-//! [`GenericHashSet`] is usually a better choice for
+//! [`HashSet`] is usually a better choice for
 //! performance, but the `OrdSet` has the advantage of only requiring
 //! an [`Ord`][std::cmp::Ord] constraint on its values, and of being
 //! ordered, so values always come out from lowest to highest, where a
-//! [`GenericHashSet`] has no guaranteed ordering.
+//! [`HashSet`] has no guaranteed ordering.
 //!
 //! [1]: https://en.wikipedia.org/wiki/B%2B_tree
 
@@ -27,9 +27,9 @@ use archery::SharedPointerKind;
 use equivalent::Comparable;
 
 use super::map;
-use crate::hashset::GenericHashSet;
+use crate::OrdMap;
+use crate::hashset::HashSet;
 use crate::shared_ptr::DefaultSharedPtr;
-use crate::GenericOrdMap;
 
 /// Construct a set from a sequence of values.
 ///
@@ -58,36 +58,36 @@ macro_rules! ordset {
     }};
 }
 
-/// Type alias for [`GenericOrdSet`] that uses [`DefaultSharedPtr`] as the pointer type.
-///
-/// [GenericOrdSet]: ./struct.GenericOrdSet.html
-/// [DefaultSharedPtr]: ../shared_ptr/type.DefaultSharedPtr.html
-pub type OrdSet<A> = GenericOrdSet<A, DefaultSharedPtr>;
-
 /// An ordered set.
 ///
 /// An immutable ordered map implemented as a B+tree [1].
 ///
 /// Most operations on this type of set are O(log n). A
-/// [`GenericHashSet`] is usually a better choice for
+/// [`HashSet`] is usually a better choice for
 /// performance, but the `OrdSet` has the advantage of only requiring
 /// an [`Ord`][std::cmp::Ord] constraint on its values, and of being
 /// ordered, so values always come out from lowest to highest, where a
-/// [`GenericHashSet`] has no guaranteed ordering.
+/// [`HashSet`] has no guaranteed ordering.
 ///
 /// [1]: https://en.wikipedia.org/wiki/B%2B_tree
-pub struct GenericOrdSet<A, P: SharedPointerKind> {
-    map: GenericOrdMap<A, (), P>,
+pub struct OrdSet<A, P: SharedPointerKind = DefaultSharedPtr> {
+    map: OrdMap<A, (), P>,
 }
 
-impl<A, P: SharedPointerKind> GenericOrdSet<A, P> {
+impl<A> OrdSet<A, DefaultSharedPtr> {
     /// Construct an empty set.
     #[inline]
     #[must_use]
     pub fn new() -> Self {
-        GenericOrdSet {
-            map: GenericOrdMap::new(),
-        }
+        Default::default()
+    }
+}
+impl<A, P: SharedPointerKind> OrdSet<A, P> {
+    /// Construct an empty set with a custom shared kind
+    #[inline]
+    #[must_use]
+    pub fn with_kind() -> Self {
+        Default::default()
     }
 
     /// Construct a set with a single value.
@@ -103,8 +103,8 @@ impl<A, P: SharedPointerKind> GenericOrdSet<A, P> {
     #[inline]
     #[must_use]
     pub fn unit(a: A) -> Self {
-        GenericOrdSet {
-            map: GenericOrdMap::unit(a, ()),
+        OrdSet {
+            map: OrdMap::unit(a, ()),
         }
     }
 
@@ -181,7 +181,7 @@ impl<A, P: SharedPointerKind> GenericOrdSet<A, P> {
     }
 }
 
-impl<A, P> GenericOrdSet<A, P>
+impl<A, P> OrdSet<A, P>
 where
     A: Ord,
     P: SharedPointerKind,
@@ -392,7 +392,7 @@ where
     }
 }
 
-impl<A, P> GenericOrdSet<A, P>
+impl<A, P> OrdSet<A, P>
 where
     A: Ord + Clone,
     P: SharedPointerKind,
@@ -717,40 +717,40 @@ where
 
 // Core traits
 
-impl<A, P: SharedPointerKind> Clone for GenericOrdSet<A, P> {
+impl<A, P: SharedPointerKind> Clone for OrdSet<A, P> {
     /// Clone a set.
     ///
     /// Time: O(1)
     #[inline]
     fn clone(&self) -> Self {
-        GenericOrdSet {
+        OrdSet {
             map: self.map.clone(),
         }
     }
 }
 
 // TODO: Support PartialEq for OrdSet that have different P
-impl<A: Ord, P: SharedPointerKind> PartialEq for GenericOrdSet<A, P> {
+impl<A: Ord, P: SharedPointerKind> PartialEq for OrdSet<A, P> {
     fn eq(&self, other: &Self) -> bool {
         self.map.eq(&other.map)
     }
 }
 
-impl<A: Ord, P: SharedPointerKind> Eq for GenericOrdSet<A, P> {}
+impl<A: Ord, P: SharedPointerKind> Eq for OrdSet<A, P> {}
 
-impl<A: Ord, P: SharedPointerKind> PartialOrd for GenericOrdSet<A, P> {
+impl<A: Ord, P: SharedPointerKind> PartialOrd for OrdSet<A, P> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<A: Ord, P: SharedPointerKind> Ord for GenericOrdSet<A, P> {
+impl<A: Ord, P: SharedPointerKind> Ord for OrdSet<A, P> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.iter().cmp(other.iter())
     }
 }
 
-impl<A: Ord + Hash, P: SharedPointerKind> Hash for GenericOrdSet<A, P> {
+impl<A: Ord + Hash, P: SharedPointerKind> Hash for OrdSet<A, P> {
     fn hash<H>(&self, state: &mut H)
     where
         H: Hasher,
@@ -761,54 +761,56 @@ impl<A: Ord + Hash, P: SharedPointerKind> Hash for GenericOrdSet<A, P> {
     }
 }
 
-impl<A, P: SharedPointerKind> Default for GenericOrdSet<A, P> {
+impl<A, P: SharedPointerKind> Default for OrdSet<A, P> {
     fn default() -> Self {
-        GenericOrdSet::new()
+        OrdSet {
+            map: OrdMap::with_kind(),
+        }
     }
 }
 
-impl<A: Ord + Clone, P: SharedPointerKind> Add for GenericOrdSet<A, P> {
-    type Output = GenericOrdSet<A, P>;
+impl<A: Ord + Clone, P: SharedPointerKind> Add for OrdSet<A, P> {
+    type Output = OrdSet<A, P>;
 
     fn add(self, other: Self) -> Self::Output {
         self.union(other)
     }
 }
 
-impl<A: Ord + Clone, P: SharedPointerKind> Add for &GenericOrdSet<A, P> {
-    type Output = GenericOrdSet<A, P>;
+impl<A: Ord + Clone, P: SharedPointerKind> Add for &OrdSet<A, P> {
+    type Output = OrdSet<A, P>;
 
     fn add(self, other: Self) -> Self::Output {
         self.clone().union(other.clone())
     }
 }
 
-impl<A: Ord + Clone, P: SharedPointerKind> Mul for GenericOrdSet<A, P> {
-    type Output = GenericOrdSet<A, P>;
+impl<A: Ord + Clone, P: SharedPointerKind> Mul for OrdSet<A, P> {
+    type Output = OrdSet<A, P>;
 
     fn mul(self, other: Self) -> Self::Output {
         self.intersection(other)
     }
 }
 
-impl<A: Ord + Clone, P: SharedPointerKind> Mul for &GenericOrdSet<A, P> {
-    type Output = GenericOrdSet<A, P>;
+impl<A: Ord + Clone, P: SharedPointerKind> Mul for &OrdSet<A, P> {
+    type Output = OrdSet<A, P>;
 
     fn mul(self, other: Self) -> Self::Output {
         self.clone().intersection(other.clone())
     }
 }
 
-impl<A: Ord + Clone, P: SharedPointerKind> Sum for GenericOrdSet<A, P> {
+impl<A: Ord + Clone, P: SharedPointerKind> Sum for OrdSet<A, P> {
     fn sum<I>(it: I) -> Self
     where
         I: Iterator<Item = Self>,
     {
-        it.fold(Self::new(), |a, b| a + b)
+        it.fold(Self::with_kind(), |a, b| a + b)
     }
 }
 
-impl<A, R, P> Extend<R> for GenericOrdSet<A, P>
+impl<A, R, P> Extend<R> for OrdSet<A, P>
 where
     A: Ord + Clone + From<R>,
     P: SharedPointerKind,
@@ -823,7 +825,7 @@ where
     }
 }
 
-impl<A: Ord + Debug, P: SharedPointerKind> Debug for GenericOrdSet<A, P> {
+impl<A: Ord + Debug, P: SharedPointerKind> Debug for OrdSet<A, P> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         f.debug_set().entries(self.iter()).finish()
     }
@@ -1011,7 +1013,7 @@ where
 {
 }
 
-impl<A, R, P> FromIterator<R> for GenericOrdSet<A, P>
+impl<A, R, P> FromIterator<R> for OrdSet<A, P>
 where
     A: Ord + Clone + From<R>,
     P: SharedPointerKind,
@@ -1020,7 +1022,7 @@ where
     where
         T: IntoIterator<Item = R>,
     {
-        let mut out = Self::new();
+        let mut out = Self::with_kind();
         for item in i {
             out.insert(From::from(item));
         }
@@ -1028,7 +1030,7 @@ where
     }
 }
 
-impl<'a, A, P> IntoIterator for &'a GenericOrdSet<A, P>
+impl<'a, A, P> IntoIterator for &'a OrdSet<A, P>
 where
     A: 'a + Ord,
     P: SharedPointerKind,
@@ -1041,7 +1043,7 @@ where
     }
 }
 
-impl<A, P> IntoIterator for GenericOrdSet<A, P>
+impl<A, P> IntoIterator for OrdSet<A, P>
 where
     A: Ord + Clone,
     P: SharedPointerKind,
@@ -1058,19 +1060,19 @@ where
 
 // Conversions
 
-impl<A, OA, P1, P2> From<&GenericOrdSet<&A, P2>> for GenericOrdSet<OA, P1>
+impl<A, OA, P1, P2> From<&OrdSet<&A, P2>> for OrdSet<OA, P1>
 where
     A: ToOwned<Owned = OA> + Ord + ?Sized,
     OA: Ord + Clone,
     P1: SharedPointerKind,
     P2: SharedPointerKind,
 {
-    fn from(set: &GenericOrdSet<&A, P2>) -> Self {
+    fn from(set: &OrdSet<&A, P2>) -> Self {
         set.iter().map(|a| (*a).to_owned()).collect()
     }
 }
 
-impl<'a, A, P> From<&'a [A]> for GenericOrdSet<A, P>
+impl<'a, A, P> From<&'a [A]> for OrdSet<A, P>
 where
     A: Ord + Clone,
     P: SharedPointerKind,
@@ -1080,20 +1082,20 @@ where
     }
 }
 
-impl<A: Ord + Clone, P: SharedPointerKind> From<Vec<A>> for GenericOrdSet<A, P> {
+impl<A: Ord + Clone, P: SharedPointerKind> From<Vec<A>> for OrdSet<A, P> {
     fn from(vec: Vec<A>) -> Self {
         vec.into_iter().collect()
     }
 }
 
-impl<A: Ord + Clone, P: SharedPointerKind> From<&Vec<A>> for GenericOrdSet<A, P> {
+impl<A: Ord + Clone, P: SharedPointerKind> From<&Vec<A>> for OrdSet<A, P> {
     fn from(vec: &Vec<A>) -> Self {
         vec.iter().cloned().collect()
     }
 }
 
 impl<A: Eq + Hash + Ord + Clone, P: SharedPointerKind> From<collections::HashSet<A>>
-    for GenericOrdSet<A, P>
+    for OrdSet<A, P>
 {
     fn from(hash_set: collections::HashSet<A>) -> Self {
         hash_set.into_iter().collect()
@@ -1101,37 +1103,37 @@ impl<A: Eq + Hash + Ord + Clone, P: SharedPointerKind> From<collections::HashSet
 }
 
 impl<A: Eq + Hash + Ord + Clone, P: SharedPointerKind> From<&collections::HashSet<A>>
-    for GenericOrdSet<A, P>
+    for OrdSet<A, P>
 {
     fn from(hash_set: &collections::HashSet<A>) -> Self {
         hash_set.iter().cloned().collect()
     }
 }
 
-impl<A: Ord + Clone, P: SharedPointerKind> From<collections::BTreeSet<A>> for GenericOrdSet<A, P> {
+impl<A: Ord + Clone, P: SharedPointerKind> From<collections::BTreeSet<A>> for OrdSet<A, P> {
     fn from(btree_set: collections::BTreeSet<A>) -> Self {
         btree_set.into_iter().collect()
     }
 }
 
-impl<A: Ord + Clone, P: SharedPointerKind> From<&collections::BTreeSet<A>> for GenericOrdSet<A, P> {
+impl<A: Ord + Clone, P: SharedPointerKind> From<&collections::BTreeSet<A>> for OrdSet<A, P> {
     fn from(btree_set: &collections::BTreeSet<A>) -> Self {
         btree_set.iter().cloned().collect()
     }
 }
 
 impl<A: Hash + Eq + Ord + Clone, S: BuildHasher, P1: SharedPointerKind, P2: SharedPointerKind>
-    From<GenericHashSet<A, S, P2>> for GenericOrdSet<A, P1>
+    From<HashSet<A, S, P2>> for OrdSet<A, P1>
 {
-    fn from(hashset: GenericHashSet<A, S, P2>) -> Self {
+    fn from(hashset: HashSet<A, S, P2>) -> Self {
         hashset.into_iter().collect()
     }
 }
 
 impl<A: Hash + Eq + Ord + Clone, S: BuildHasher, P1: SharedPointerKind, P2: SharedPointerKind>
-    From<&GenericHashSet<A, S, P2>> for GenericOrdSet<A, P1>
+    From<&HashSet<A, S, P2>> for OrdSet<A, P1>
 {
-    fn from(hashset: &GenericHashSet<A, S, P2>) -> Self {
+    fn from(hashset: &HashSet<A, S, P2>) -> Self {
         hashset.into_iter().cloned().collect()
     }
 }

--- a/src/quickcheck.rs
+++ b/src/quickcheck.rs
@@ -1,50 +1,40 @@
-use crate::{
-    shared_ptr::SharedPointerKind, GenericHashMap, GenericHashSet, GenericOrdMap, GenericOrdSet,
-    GenericVector,
-};
+use crate::{HashMap, HashSet, OrdMap, OrdSet, Vector, shared_ptr::SharedPointerKind};
 use ::quickcheck::{Arbitrary, Gen};
 use std::hash::{BuildHasher, Hash};
 use std::iter::FromIterator;
 
-impl<A: Arbitrary + Sync + Clone, P: SharedPointerKind + 'static> Arbitrary
-    for GenericVector<A, P>
-{
+impl<A: Arbitrary + Sync + Clone, P: SharedPointerKind + 'static> Arbitrary for Vector<A, P> {
     fn arbitrary(g: &mut Gen) -> Self {
-        GenericVector::from_iter(Vec::<A>::arbitrary(g))
+        Vector::from_iter(Vec::<A>::arbitrary(g))
     }
 }
 
-impl<
-        K: Ord + Clone + Arbitrary + Sync,
-        V: Clone + Arbitrary + Sync,
-        P: SharedPointerKind + 'static,
-    > Arbitrary for GenericOrdMap<K, V, P>
+impl<K: Ord + Clone + Arbitrary + Sync, V: Clone + Arbitrary + Sync, P: SharedPointerKind + 'static>
+    Arbitrary for OrdMap<K, V, P>
 {
     fn arbitrary(g: &mut Gen) -> Self {
-        GenericOrdMap::from_iter(Vec::<(K, V)>::arbitrary(g))
+        OrdMap::from_iter(Vec::<(K, V)>::arbitrary(g))
     }
 }
 
-impl<A: Ord + Clone + Arbitrary + Sync, P: SharedPointerKind + 'static> Arbitrary
-    for GenericOrdSet<A, P>
-{
+impl<A: Ord + Clone + Arbitrary + Sync, P: SharedPointerKind + 'static> Arbitrary for OrdSet<A, P> {
     fn arbitrary(g: &mut Gen) -> Self {
-        GenericOrdSet::from_iter(Vec::<A>::arbitrary(g))
+        OrdSet::from_iter(Vec::<A>::arbitrary(g))
     }
 }
 
-impl<A, S, P> Arbitrary for GenericHashSet<A, S, P>
+impl<A, S, P> Arbitrary for HashSet<A, S, P>
 where
     A: Hash + Eq + Arbitrary + Sync,
     S: BuildHasher + Clone + Default + Send + Sync + 'static,
     P: SharedPointerKind + 'static,
 {
     fn arbitrary(g: &mut Gen) -> Self {
-        GenericHashSet::from_iter(Vec::<A>::arbitrary(g))
+        HashSet::from_iter(Vec::<A>::arbitrary(g))
     }
 }
 
-impl<K, V, S, P> Arbitrary for GenericHashMap<K, V, S, P>
+impl<K, V, S, P> Arbitrary for HashMap<K, V, S, P>
 where
     K: Hash + Eq + Arbitrary + Sync,
     V: Arbitrary + Sync,
@@ -52,6 +42,6 @@ where
     P: SharedPointerKind + 'static,
 {
     fn arbitrary(g: &mut Gen) -> Self {
-        GenericHashMap::from(Vec::<(K, V)>::arbitrary(g))
+        HashMap::from(Vec::<(K, V)>::arbitrary(g))
     }
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -224,18 +224,20 @@ impl<A: Serialize + Hash + Eq, S: BuildHasher + Default, P: SharedPointerKind> S
 
 // Vector
 
-impl<'de, A: Clone + Deserialize<'de>, P: SharedPointerKind> Deserialize<'de>
-    for GenericVector<A, P>
+impl<'de, A: Clone + Deserialize<'de>, P: SharedPointerKind, const CHUNK_SIZE: usize>
+    Deserialize<'de> for GenericVector<A, P, CHUNK_SIZE>
 {
     fn deserialize<D>(des: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        des.deserialize_seq(SeqVisitor::<'de, GenericVector<A, P>, A>::new())
+        des.deserialize_seq(SeqVisitor::<'de, GenericVector<A, P, CHUNK_SIZE>, A>::new())
     }
 }
 
-impl<A: Serialize, P: SharedPointerKind> Serialize for GenericVector<A, P> {
+impl<A: Serialize, P: SharedPointerKind, const CHUNK_SIZE: usize> Serialize
+    for GenericVector<A, P, CHUNK_SIZE>
+{
     fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -9,11 +9,11 @@ use std::fmt;
 use std::hash::{BuildHasher, Hash};
 use std::marker::PhantomData;
 
-use crate::hashmap::GenericHashMap;
-use crate::hashset::GenericHashSet;
-use crate::ordmap::GenericOrdMap;
-use crate::ordset::GenericOrdSet;
-use crate::vector::GenericVector;
+use crate::hashmap::HashMap;
+use crate::hashset::HashSet;
+use crate::ordmap::OrdMap;
+use crate::ordset::OrdSet;
+use crate::vector::Vector;
 
 struct SeqVisitor<'de, S, A> {
     phantom_s: PhantomData<S>,
@@ -105,7 +105,7 @@ where
 // Set
 
 impl<'de, A: Deserialize<'de> + Ord + Clone, P: SharedPointerKind> Deserialize<'de>
-    for GenericOrdSet<A, P>
+    for OrdSet<A, P>
 {
     fn deserialize<D>(des: D) -> Result<Self, D::Error>
     where
@@ -115,7 +115,7 @@ impl<'de, A: Deserialize<'de> + Ord + Clone, P: SharedPointerKind> Deserialize<'
     }
 }
 
-impl<A: Ord + Serialize, P: SharedPointerKind> Serialize for GenericOrdSet<A, P> {
+impl<A: Ord + Serialize, P: SharedPointerKind> Serialize for OrdSet<A, P> {
     fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -131,17 +131,17 @@ impl<A: Ord + Serialize, P: SharedPointerKind> Serialize for GenericOrdSet<A, P>
 // Map
 
 impl<'de, K: Deserialize<'de> + Ord + Clone, V: Deserialize<'de> + Clone, P: SharedPointerKind>
-    Deserialize<'de> for GenericOrdMap<K, V, P>
+    Deserialize<'de> for OrdMap<K, V, P>
 {
     fn deserialize<D>(des: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        des.deserialize_map(MapVisitor::<'de, GenericOrdMap<K, V, P>, K, V>::new())
+        des.deserialize_map(MapVisitor::<'de, OrdMap<K, V, P>, K, V>::new())
     }
 }
 
-impl<K: Serialize + Ord, V: Serialize, P: SharedPointerKind> Serialize for GenericOrdMap<K, V, P> {
+impl<K: Serialize + Ord, V: Serialize, P: SharedPointerKind> Serialize for OrdMap<K, V, P> {
     fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -156,7 +156,7 @@ impl<K: Serialize + Ord, V: Serialize, P: SharedPointerKind> Serialize for Gener
 
 // HashMap
 
-impl<'de, K, V, S, P: SharedPointerKind> Deserialize<'de> for GenericHashMap<K, V, S, P>
+impl<'de, K, V, S, P: SharedPointerKind> Deserialize<'de> for HashMap<K, V, S, P>
 where
     K: Deserialize<'de> + Hash + Eq + Clone,
     V: Deserialize<'de> + Clone,
@@ -167,11 +167,11 @@ where
     where
         D: Deserializer<'de>,
     {
-        des.deserialize_map(MapVisitor::<'de, GenericHashMap<K, V, S, P>, K, V>::new())
+        des.deserialize_map(MapVisitor::<'de, HashMap<K, V, S, P>, K, V>::new())
     }
 }
 
-impl<K, V, S, P> Serialize for GenericHashMap<K, V, S, P>
+impl<K, V, S, P> Serialize for HashMap<K, V, S, P>
 where
     K: Serialize + Hash + Eq,
     V: Serialize,
@@ -193,11 +193,11 @@ where
 // HashSet
 
 impl<
-        'de,
-        A: Deserialize<'de> + Hash + Eq + Clone,
-        S: BuildHasher + Default + Clone,
-        P: SharedPointerKind,
-    > Deserialize<'de> for GenericHashSet<A, S, P>
+    'de,
+    A: Deserialize<'de> + Hash + Eq + Clone,
+    S: BuildHasher + Default + Clone,
+    P: SharedPointerKind,
+> Deserialize<'de> for HashSet<A, S, P>
 {
     fn deserialize<D>(des: D) -> Result<Self, D::Error>
     where
@@ -208,7 +208,7 @@ impl<
 }
 
 impl<A: Serialize + Hash + Eq, S: BuildHasher + Default, P: SharedPointerKind> Serialize
-    for GenericHashSet<A, S, P>
+    for HashSet<A, S, P>
 {
     fn serialize<Ser>(&self, ser: Ser) -> Result<Ser::Ok, Ser::Error>
     where
@@ -225,18 +225,18 @@ impl<A: Serialize + Hash + Eq, S: BuildHasher + Default, P: SharedPointerKind> S
 // Vector
 
 impl<'de, A: Clone + Deserialize<'de>, P: SharedPointerKind, const CHUNK_SIZE: usize>
-    Deserialize<'de> for GenericVector<A, P, CHUNK_SIZE>
+    Deserialize<'de> for Vector<A, P, CHUNK_SIZE>
 {
     fn deserialize<D>(des: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        des.deserialize_seq(SeqVisitor::<'de, GenericVector<A, P, CHUNK_SIZE>, A>::new())
+        des.deserialize_seq(SeqVisitor::<'de, Vector<A, P, CHUNK_SIZE>, A>::new())
     }
 }
 
 impl<A: Serialize, P: SharedPointerKind, const CHUNK_SIZE: usize> Serialize
-    for GenericVector<A, P, CHUNK_SIZE>
+    for Vector<A, P, CHUNK_SIZE>
 {
     fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
     where
@@ -255,8 +255,8 @@ impl<A: Serialize, P: SharedPointerKind, const CHUNK_SIZE: usize> Serialize
 #[cfg(test)]
 mod test {
     use crate::{
-        proptest::{hash_map, hash_set, ord_map, ord_set, vector},
         HashMap, HashSet, OrdMap, OrdSet, Vector,
+        proptest::{hash_map, hash_set, ord_map, ord_set, vector},
     };
     use proptest::num::i32;
     use proptest::proptest;

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -20,8 +20,11 @@ fn gen_range<R: RngCore>(rng: &mut R, min: usize, max: usize) -> usize {
 // additional passes to find the exact partition places. This allows us to split the focus into
 // three correctly sized parts for less than, equal to and greater than items. As a bonus this
 // doesn't need to reorder the equal items to the center of the vector.
-fn do_quicksort<A, F, R, P>(vector: FocusMut<'_, A, P>, cmp: &F, rng: &mut R)
-where
+fn do_quicksort<A, F, R, P, const CHUNK_SIZE: usize>(
+    vector: FocusMut<'_, A, P, CHUNK_SIZE>,
+    cmp: &F,
+    rng: &mut R,
+) where
     A: Clone,
     F: Fn(&A, &A) -> Ordering,
     R: RngCore,
@@ -174,8 +177,10 @@ where
     }
 }
 
-pub(crate) fn quicksort<A, F, P>(vector: FocusMut<'_, A, P>, cmp: &F)
-where
+pub(crate) fn quicksort<A, F, P, const CHUNK_SIZE: usize>(
+    vector: FocusMut<'_, A, P, CHUNK_SIZE>,
+    cmp: &F,
+) where
     A: Clone,
     F: Fn(&A, &A) -> Ordering,
     P: SharedPointerKind,

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -4,11 +4,11 @@
 
 use crate::vector::FocusMut;
 use archery::SharedPointerKind;
-use rand_core::{RngCore, SeedableRng};
+use rand_core::{Rng, SeedableRng};
 use std::cmp::Ordering;
 use std::mem;
 
-fn gen_range<R: RngCore>(rng: &mut R, min: usize, max: usize) -> usize {
+fn gen_range<R: Rng>(rng: &mut R, min: usize, max: usize) -> usize {
     let range = max - min;
     min + (rng.next_u64() as usize % range)
 }
@@ -27,7 +27,7 @@ fn do_quicksort<A, F, R, P, const CHUNK_SIZE: usize>(
 ) where
     A: Clone,
     F: Fn(&A, &A) -> Ordering,
-    R: RngCore,
+    R: Rng,
     P: SharedPointerKind,
 {
     if vector.len() <= 1 {

--- a/src/tests/hashset.rs
+++ b/src/tests/hashset.rs
@@ -30,11 +30,11 @@ where
         writeln!(out, "let mut set = HashSet::new();")?;
         for action in &self.0 {
             match action {
-                Action::Insert(ref value) => {
+                Action::Insert(value) => {
                     expected.insert(value.clone());
                     writeln!(out, "set.insert({:?});", value)?;
                 }
-                Action::Remove(ref value) => {
+                Action::Remove(value) => {
                     expected.remove(value);
                     writeln!(out, "set.remove({:?});", value)?;
                 }

--- a/src/tests/hashset.rs
+++ b/src/tests/hashset.rs
@@ -79,7 +79,7 @@ proptest! {
                 }
             }
             assert_eq!(nat.len(), set.len());
-            assert_eq!(HashSet::from(nat.clone()), set);
+            assert_eq!(HashSet::<u8>::from(nat.clone()), set);
         }
     }
 }

--- a/src/tests/ordset.rs
+++ b/src/tests/ordset.rs
@@ -29,11 +29,11 @@ where
         writeln!(out, "let mut set = OrdSet::new();")?;
         for action in &self.0 {
             match action {
-                Action::Insert(ref value) => {
+                Action::Insert(value) => {
                     expected.insert(value.clone());
                     writeln!(out, "set.insert({:?});", value)?;
                 }
-                Action::Remove(ref value) => {
+                Action::Remove(value) => {
                     expected.remove(value);
                     writeln!(out, "set.remove({:?});", value)?;
                 }

--- a/src/tests/vector.rs
+++ b/src/tests/vector.rs
@@ -37,11 +37,11 @@ where
         writeln!(out, "let mut vec = Vector::new();")?;
         for action in &self.0 {
             match action {
-                Action::PushFront(ref value) => {
+                Action::PushFront(value) => {
                     expected.insert(0, value.clone());
                     writeln!(out, "vec.push_front({:?});", value)?
                 }
-                Action::PushBack(ref value) => {
+                Action::PushBack(value) => {
                     expected.push(value.clone());
                     writeln!(out, "vec.push_back({:?});", value)?
                 }
@@ -55,12 +55,12 @@ where
                     expected.pop();
                     writeln!(out, "vec.pop_back();")?
                 }
-                Action::Insert(ref index, ref value) => {
+                Action::Insert(index, value) => {
                     let index = cap_index(expected.len(), *index);
                     expected.insert(index, value.clone());
                     writeln!(out, "vec.insert({:?}, {:?});", index, value)?
                 }
-                Action::Remove(ref index) => {
+                Action::Remove(index) => {
                     if !expected.is_empty() {
                         let index = cap_index(expected.len(), *index);
                         expected.remove(index);
@@ -69,7 +69,7 @@ where
                         continue;
                     }
                 }
-                Action::JoinLeft(ref vec) => {
+                Action::JoinLeft(vec) => {
                     let mut vec_new = vec.clone();
                     vec_new.append(&mut expected);
                     expected = vec_new;
@@ -82,7 +82,7 @@ where
                     writeln!(out, "vec_new.append(vec);")?;
                     writeln!(out, "vec = vec_new;")?
                 }
-                Action::JoinRight(ref vec) => {
+                Action::JoinRight(vec) => {
                     expected.append(&mut vec.clone());
                     writeln!(
                         out,
@@ -91,12 +91,12 @@ where
                         vec.len()
                     )?
                 }
-                Action::SplitLeft(ref index) => {
+                Action::SplitLeft(index) => {
                     let index = cap_index(expected.len(), *index);
                     expected.truncate(index);
                     writeln!(out, "vec.split_off({:?});", index)?
                 }
-                Action::SplitRight(ref index) => {
+                Action::SplitRight(index) => {
                     let index = cap_index(expected.len(), *index);
                     expected = expected.split_off(index);
                     writeln!(out, "vec = vec.split_off({:?});", index)?
@@ -111,11 +111,7 @@ where
 }
 
 fn cap_index(len: usize, index: usize) -> usize {
-    if len == 0 {
-        0
-    } else {
-        index % len
-    }
+    if len == 0 { 0 } else { index % len }
 }
 
 proptest! {

--- a/src/tests/vector.rs
+++ b/src/tests/vector.rs
@@ -3,7 +3,7 @@
 use std::fmt::{Debug, Error, Formatter, Write};
 use std::iter::FromIterator;
 
-use crate::{GenericVector, Vector};
+use crate::Vector;
 
 use proptest::proptest;
 use proptest_derive::Arbitrary;
@@ -170,7 +170,7 @@ proptest! {
                     assert_eq!(len - 1, vec.len());
                 }
                 Action::JoinLeft(mut new_nat) => {
-                    let mut new_vec = GenericVector::from_iter(new_nat.iter().cloned());
+                    let mut new_vec = Vector::from_iter(new_nat.iter().cloned());
                     let add_len = new_nat.len();
                     let len = vec.len();
                     new_vec.append(vec);
@@ -180,7 +180,7 @@ proptest! {
                     assert_eq!(len + add_len, vec.len());
                 }
                 Action::JoinRight(mut new_nat) => {
-                    let new_vec = GenericVector::from_iter(new_nat.iter().cloned());
+                    let new_vec = Vector::from_iter(new_nat.iter().cloned());
                     let add_len = new_nat.len();
                     let len = vec.len();
                     vec.append(new_vec);
@@ -194,7 +194,7 @@ proptest! {
                     let nat_right = nat.split_off(index);
                     assert_eq!(index, vec.len());
                     assert_eq!(len - index, vec_right.len());
-                    assert_eq!(GenericVector::from_iter(nat_right.iter().cloned()), vec_right);
+                    assert_eq!(Vector::from_iter(nat_right.iter().cloned()), vec_right);
                 }
                 Action::SplitRight(index) => {
                     let index = cap_index(vec.len(), index);
@@ -203,7 +203,7 @@ proptest! {
                     let nat_right = nat.split_off(index);
                     assert_eq!(index, vec.len());
                     assert_eq!(len - index, vec_right.len());
-                    assert_eq!(GenericVector::from_iter(nat.iter().cloned()), vec);
+                    assert_eq!(Vector::from_iter(nat.iter().cloned()), vec);
                     vec = vec_right;
                     nat = nat_right;
                 }
@@ -225,5 +225,5 @@ fn test_inserts() {
     let mut rv: Vec<usize> = Vec::new();
     rv.extend((0..N).skip(1).step_by(2));
     rv.extend((0..N).step_by(2).rev());
-    assert_eq!(GenericVector::from_iter(rv.iter().cloned()), v);
+    assert_eq!(Vector::from_iter(rv.iter().cloned()), v);
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -41,10 +41,10 @@ where
 
 #[cfg(test)]
 macro_rules! assert_covariant {
-    ($name:ident<$($gen:tt),*> in $param:ident) => {
+    ($name:ident<$($g:tt),*> in $param:ident) => {
         #[allow(dead_code, unused_assignments, unused_variables)]
         const _: () = {
-            type Tmp<$param> = $name<$($gen),*>;
+            type Tmp<$param> = $name<$($g),*>;
             fn assign<'a, 'b: 'a>(src: Tmp<&'b i32>, mut dst: Tmp<&'a i32>) {
                 dst = src;
             }

--- a/src/vector/focus.rs
+++ b/src/vector/focus.rs
@@ -114,7 +114,11 @@ where
     ///
     /// [Vector]: type.Vector.html
     pub fn new(vector: &'a GenericVector<A, P>) -> Self {
-        match &vector.vector {
+        Self::new_inner(&vector.vector)
+    }
+
+    pub(super) fn new_inner(vector: &'a crate::vector::VectorInner<A, P>) -> Self {
+        match vector {
             Inline(chunk) => Focus::Single(chunk),
             Single(chunk) => Focus::Single(chunk),
             Full(tree) => Focus::Full(TreeFocus::new(tree)),

--- a/src/vector/focus.rs
+++ b/src/vector/focus.rs
@@ -13,7 +13,7 @@ use crate::nodes::chunk::Chunk;
 use crate::sync::Lock;
 use crate::util::to_range;
 use crate::vector::{
-    GenericVector, Iter, IterMut,
+    Vector, Iter, IterMut,
     VectorInner::{Full, Inline, Single},
     RRB,
 };
@@ -113,7 +113,7 @@ where
     /// Construct a `Focus` for a [`Vector`][Vector].
     ///
     /// [Vector]: type.Vector.html
-    pub fn new(vector: &'a GenericVector<A, P, CHUNK_SIZE>) -> Self {
+    pub fn new(vector: &'a Vector<A, P, CHUNK_SIZE>) -> Self {
         Self::new_inner(&vector.vector)
     }
 
@@ -637,7 +637,7 @@ where
     A: Clone + 'a,
 {
     /// Construct a `FocusMut` for a `Vector`.
-    pub fn new(vector: &'a mut GenericVector<A, P, CHUNK_SIZE>) -> Self {
+    pub fn new(vector: &'a mut Vector<A, P, CHUNK_SIZE>) -> Self {
         match &mut vector.vector {
             Inline(chunk) => FocusMut::Single(chunk),
             Single(chunk) => FocusMut::Single(SharedPointer::make_mut(chunk).as_mut_slice()),

--- a/src/vector/focus.rs
+++ b/src/vector/focus.rs
@@ -13,9 +13,8 @@ use crate::nodes::chunk::Chunk;
 use crate::sync::Lock;
 use crate::util::to_range;
 use crate::vector::{
-    Vector, Iter, IterMut,
+    Iter, IterMut, RRB, Vector,
     VectorInner::{Full, Inline, Single},
-    RRB,
 };
 
 fn check_indices<const N: usize>(len: usize, indices: &[usize; N]) -> Option<()> {

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -109,12 +109,6 @@ macro_rules! vector {
     }};
 }
 
-/// Type alias for [`GenericVector`] that uses [`DefaultSharedPtr`] as the pointer type.
-///
-/// [GenericVector]: ./struct.GenericVector.html
-/// [DefaultSharedPtr]: ../shared_ptr/type.DefaultSharedPtr.html
-pub type Vector<A> = GenericVector<A, DefaultSharedPtr, { crate::config::VECTOR_CHUNK_SIZE }>;
-
 /// A persistent vector.
 ///
 /// This is a sequence of elements in insertion order - if you need a list of
@@ -151,7 +145,11 @@ pub type Vector<A> = GenericVector<A, DefaultSharedPtr, { crate::config::VECTOR_
 /// [chunkedseq]: http://deepsea.inria.fr/pasl/chunkedseq.pdf
 /// [Vec]: https://doc.rust-lang.org/std/vec/struct.Vec.html
 /// [VecDeque]: https://doc.rust-lang.org/std/collections/struct.VecDeque.html
-pub struct GenericVector<A, P: SharedPointerKind, const CHUNK_SIZE: usize> {
+pub struct Vector<
+    A,
+    P: SharedPointerKind = DefaultSharedPtr,
+    const CHUNK_SIZE: usize = { crate::config::VECTOR_CHUNK_SIZE },
+> {
     vector: VectorInner<A, P, CHUNK_SIZE>,
 }
 
@@ -200,7 +198,31 @@ impl<A, P: SharedPointerKind, const CHUNK_SIZE: usize> Clone for RRB<A, P, CHUNK
     }
 }
 
-impl<A, P: SharedPointerKind, const CHUNK_SIZE: usize> GenericVector<A, P, CHUNK_SIZE> {
+impl<A> Vector<A, DefaultSharedPtr, { crate::config::VECTOR_CHUNK_SIZE }> {
+    /// Construct an empty vector using [`DefaultSharedPtr`] and [`crate::config::VECTOR_CHUNK_SIZE`]
+    #[must_use]
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl<A, P: SharedPointerKind> Vector<A, P, { crate::config::VECTOR_CHUNK_SIZE }> {
+    /// Construct an empty vector using a custom shared kind
+    #[must_use]
+    pub fn with_kind() -> Self {
+        Default::default()
+    }
+}
+
+impl<A, const CHUNK_SIZE: usize> Vector<A, DefaultSharedPtr, CHUNK_SIZE> {
+    /// Construct an empty vector using a custom chunk size
+    #[must_use]
+    pub fn with_size() -> Self {
+        Default::default()
+    }
+}
+
+impl<A, P: SharedPointerKind, const CHUNK_SIZE: usize> Vector<A, P, CHUNK_SIZE> {
     /// True if a vector is a full inline or single chunk, ie. must be promoted
     /// to grow further.
     fn needs_promotion(&self) -> bool {
@@ -256,9 +278,8 @@ impl<A, P: SharedPointerKind, const CHUNK_SIZE: usize> GenericVector<A, P, CHUNK
         }
     }
 
-    /// Construct an empty vector.
-    #[must_use]
-    pub fn new() -> Self {
+    /// Construct an empty vector using a custom chunk size and shared kind
+    pub fn with_kind_and_size() -> Self {
         Self {
             vector: Inline(InlineArray::new()),
         }
@@ -308,7 +329,7 @@ impl<A, P: SharedPointerKind, const CHUNK_SIZE: usize> GenericVector<A, P, CHUNK
     /// Test whether a vector is currently inlined.
     ///
     /// Vectors small enough that their contents could be stored entirely inside
-    /// the space of `std::mem::size_of::<GenericVector<A, P, CHUNK_SIZE>>()` bytes are stored inline on
+    /// the space of `std::mem::size_of::<Vector<A, P, CHUNK_SIZE>>()` bytes are stored inline on
     /// the stack instead of allocating any chunks. This method returns `true` if
     /// this vector is currently inlined, or `false` if it currently has chunks allocated
     /// on the heap.
@@ -657,7 +678,7 @@ impl<A, P: SharedPointerKind, const CHUNK_SIZE: usize> GenericVector<A, P, CHUNK
     /// ```
     /// # #[macro_use] extern crate imbl;
     /// # use imbl::Vector;
-    /// let vec  = Vector::unit(1337);
+    /// let vec  = Vector::<_>::unit(1337);
     /// assert_eq!(1, vec.len());
     /// assert_eq!(
     ///   vec.get(0),
@@ -708,7 +729,7 @@ impl<A, P: SharedPointerKind, const CHUNK_SIZE: usize> GenericVector<A, P, CHUNK
     }
 }
 
-impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> GenericVector<A, P, CHUNK_SIZE> {
+impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> Vector<A, P, CHUNK_SIZE> {
     /// Get a mutable reference to the value at index `index` in a
     /// vector.
     ///
@@ -1308,7 +1329,7 @@ impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> GenericVector<A, P
     pub fn skip(&self, count: usize) -> Self {
         match count {
             0 => self.clone(),
-            count if count >= self.len() => Self::new(),
+            count if count >= self.len() => Self::with_kind_and_size(),
             count => {
                 // FIXME can be made more efficient by dropping the unwanted side without constructing it
                 self.clone().split_off(count)
@@ -1355,7 +1376,7 @@ impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> GenericVector<A, P
     {
         let r = to_range(&range, self.len());
         if r.start >= r.end || r.start >= self.len() {
-            return GenericVector::new();
+            return Vector::with_kind_and_size();
         }
         let mut middle = self.split_off(r.start);
         let right = middle.split_off(r.end - r.start);
@@ -1756,15 +1777,15 @@ fn replace_shared_pointer<A: Default, P: SharedPointerKind>(
 
 // Core traits
 
-impl<A, P: SharedPointerKind, const CHUNK_SIZE: usize> Default for GenericVector<A, P, CHUNK_SIZE> {
+impl<A, P: SharedPointerKind, const CHUNK_SIZE: usize> Default for Vector<A, P, CHUNK_SIZE> {
     fn default() -> Self {
-        Self::new()
+        Self {
+            vector: Inline(InlineArray::new()),
+        }
     }
 }
 
-impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> Clone
-    for GenericVector<A, P, CHUNK_SIZE>
-{
+impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> Clone for Vector<A, P, CHUNK_SIZE> {
     /// Clone a vector.
     ///
     /// Time: O(1), or O(n) with a very small, bounded *n* for an inline vector.
@@ -1779,9 +1800,7 @@ impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> Clone
     }
 }
 
-impl<A: Debug, P: SharedPointerKind, const CHUNK_SIZE: usize> Debug
-    for GenericVector<A, P, CHUNK_SIZE>
-{
+impl<A: Debug, P: SharedPointerKind, const CHUNK_SIZE: usize> Debug for Vector<A, P, CHUNK_SIZE> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         f.debug_list().entries(self.iter()).finish()
         // match self {
@@ -1796,34 +1815,30 @@ impl<A: Debug, P: SharedPointerKind, const CHUNK_SIZE: usize> Debug
 }
 
 impl<A: PartialEq, P: SharedPointerKind, const CHUNK_SIZE: usize> PartialEq
-    for GenericVector<A, P, CHUNK_SIZE>
+    for Vector<A, P, CHUNK_SIZE>
 {
     fn eq(&self, other: &Self) -> bool {
         self.len() == other.len() && self.iter().eq(other.iter())
     }
 }
 
-impl<A: Eq, P: SharedPointerKind, const CHUNK_SIZE: usize> Eq for GenericVector<A, P, CHUNK_SIZE> {}
+impl<A: Eq, P: SharedPointerKind, const CHUNK_SIZE: usize> Eq for Vector<A, P, CHUNK_SIZE> {}
 
 impl<A: PartialOrd, P: SharedPointerKind, const CHUNK_SIZE: usize> PartialOrd
-    for GenericVector<A, P, CHUNK_SIZE>
+    for Vector<A, P, CHUNK_SIZE>
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.iter().partial_cmp(other.iter())
     }
 }
 
-impl<A: Ord, P: SharedPointerKind, const CHUNK_SIZE: usize> Ord
-    for GenericVector<A, P, CHUNK_SIZE>
-{
+impl<A: Ord, P: SharedPointerKind, const CHUNK_SIZE: usize> Ord for Vector<A, P, CHUNK_SIZE> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.iter().cmp(other.iter())
     }
 }
 
-impl<A: Hash, P: SharedPointerKind, const CHUNK_SIZE: usize> Hash
-    for GenericVector<A, P, CHUNK_SIZE>
-{
+impl<A: Hash, P: SharedPointerKind, const CHUNK_SIZE: usize> Hash for Vector<A, P, CHUNK_SIZE> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         for i in self {
             i.hash(state)
@@ -1831,21 +1846,17 @@ impl<A: Hash, P: SharedPointerKind, const CHUNK_SIZE: usize> Hash
     }
 }
 
-impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> Sum
-    for GenericVector<A, P, CHUNK_SIZE>
-{
+impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> Sum for Vector<A, P, CHUNK_SIZE> {
     fn sum<I>(it: I) -> Self
     where
         I: Iterator<Item = Self>,
     {
-        it.fold(Self::new(), |a, b| a + b)
+        it.fold(Self::with_kind_and_size(), |a, b| a + b)
     }
 }
 
-impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> Add
-    for GenericVector<A, P, CHUNK_SIZE>
-{
-    type Output = GenericVector<A, P, CHUNK_SIZE>;
+impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> Add for Vector<A, P, CHUNK_SIZE> {
+    type Output = Vector<A, P, CHUNK_SIZE>;
 
     /// Concatenate two vectors.
     ///
@@ -1856,10 +1867,8 @@ impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> Add
     }
 }
 
-impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> Add
-    for &GenericVector<A, P, CHUNK_SIZE>
-{
-    type Output = GenericVector<A, P, CHUNK_SIZE>;
+impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> Add for &Vector<A, P, CHUNK_SIZE> {
+    type Output = Vector<A, P, CHUNK_SIZE>;
 
     /// Concatenate two vectors.
     ///
@@ -1872,7 +1881,7 @@ impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> Add
 }
 
 impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> Extend<A>
-    for GenericVector<A, P, CHUNK_SIZE>
+    for Vector<A, P, CHUNK_SIZE>
 {
     /// Add values to the end of a vector by consuming an iterator.
     ///
@@ -1887,9 +1896,7 @@ impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> Extend<A>
     }
 }
 
-impl<A, P: SharedPointerKind, const CHUNK_SIZE: usize> Index<usize>
-    for GenericVector<A, P, CHUNK_SIZE>
-{
+impl<A, P: SharedPointerKind, const CHUNK_SIZE: usize> Index<usize> for Vector<A, P, CHUNK_SIZE> {
     type Output = A;
     /// Get a reference to the value at index `index` in the vector.
     ///
@@ -1907,7 +1914,7 @@ impl<A, P: SharedPointerKind, const CHUNK_SIZE: usize> Index<usize>
 }
 
 impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> IndexMut<usize>
-    for GenericVector<A, P, CHUNK_SIZE>
+    for Vector<A, P, CHUNK_SIZE>
 {
     /// Get a mutable reference to the value at index `index` in the
     /// vector.
@@ -1924,7 +1931,7 @@ impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> IndexMut<usize>
 // Conversions
 
 impl<'a, A, P: SharedPointerKind, const CHUNK_SIZE: usize> IntoIterator
-    for &'a GenericVector<A, P, CHUNK_SIZE>
+    for &'a Vector<A, P, CHUNK_SIZE>
 {
     type Item = &'a A;
     type IntoIter = Iter<'a, A, P, CHUNK_SIZE>;
@@ -1934,7 +1941,7 @@ impl<'a, A, P: SharedPointerKind, const CHUNK_SIZE: usize> IntoIterator
 }
 
 impl<'a, A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> IntoIterator
-    for &'a mut GenericVector<A, P, CHUNK_SIZE>
+    for &'a mut Vector<A, P, CHUNK_SIZE>
 {
     type Item = &'a mut A;
     type IntoIter = IterMut<'a, A, P, CHUNK_SIZE>;
@@ -1944,7 +1951,7 @@ impl<'a, A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> IntoIterator
 }
 
 impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> IntoIterator
-    for GenericVector<A, P, CHUNK_SIZE>
+    for Vector<A, P, CHUNK_SIZE>
 {
     type Item = A;
     type IntoIter = ConsumingIter<A, P, CHUNK_SIZE>;
@@ -1954,7 +1961,7 @@ impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> IntoIterator
 }
 
 impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> FromIterator<A>
-    for GenericVector<A, P, CHUNK_SIZE>
+    for Vector<A, P, CHUNK_SIZE>
 {
     /// Create a vector from an iterator.
     ///
@@ -1963,7 +1970,7 @@ impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> FromIterator<A>
     where
         I: IntoIterator<Item = A>,
     {
-        let mut seq = Self::new();
+        let mut seq = Self::with_kind_and_size();
         for item in iter {
             seq.push_back(item)
         }
@@ -1971,21 +1978,21 @@ impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> FromIterator<A>
     }
 }
 
-impl<A, OA, P1, P2, const CHUNK_SIZE: usize> From<&GenericVector<&A, P2, CHUNK_SIZE>>
-    for GenericVector<OA, P1, CHUNK_SIZE>
+impl<A, OA, P1, P2, const CHUNK_SIZE: usize> From<&Vector<&A, P2, CHUNK_SIZE>>
+    for Vector<OA, P1, CHUNK_SIZE>
 where
     A: ToOwned<Owned = OA>,
     OA: Borrow<A> + Clone,
     P1: SharedPointerKind,
     P2: SharedPointerKind,
 {
-    fn from(vec: &GenericVector<&A, P2, CHUNK_SIZE>) -> Self {
+    fn from(vec: &Vector<&A, P2, CHUNK_SIZE>) -> Self {
         vec.iter().map(|a| (*a).to_owned()).collect()
     }
 }
 
 impl<A, const N: usize, P: SharedPointerKind, const CHUNK_SIZE: usize> From<[A; N]>
-    for GenericVector<A, P, CHUNK_SIZE>
+    for Vector<A, P, CHUNK_SIZE>
 where
     A: Clone,
 {
@@ -1995,7 +2002,7 @@ where
 }
 
 impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> From<&[A]>
-    for GenericVector<A, P, CHUNK_SIZE>
+    for Vector<A, P, CHUNK_SIZE>
 {
     fn from(slice: &[A]) -> Self {
         slice.iter().cloned().collect()
@@ -2003,7 +2010,7 @@ impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> From<&[A]>
 }
 
 impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> From<Vec<A>>
-    for GenericVector<A, P, CHUNK_SIZE>
+    for Vector<A, P, CHUNK_SIZE>
 {
     /// Create a vector from a [`std::vec::Vec`][vec].
     ///
@@ -2016,7 +2023,7 @@ impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> From<Vec<A>>
 }
 
 impl<A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> From<&Vec<A>>
-    for GenericVector<A, P, CHUNK_SIZE>
+    for Vector<A, P, CHUNK_SIZE>
 {
     /// Create a vector from a [`std::vec::Vec`][vec].
     ///
@@ -2044,7 +2051,7 @@ pub struct Iter<'a, A, P: SharedPointerKind, const CHUNK_SIZE: usize> {
 }
 
 impl<'a, A, P: SharedPointerKind, const CHUNK_SIZE: usize> Iter<'a, A, P, CHUNK_SIZE> {
-    fn new(seq: &'a GenericVector<A, P, CHUNK_SIZE>) -> Self {
+    fn new(seq: &'a Vector<A, P, CHUNK_SIZE>) -> Self {
         Iter {
             focus: seq.focus(),
             front_index: 0,
@@ -2153,7 +2160,7 @@ impl<'a, A, P: SharedPointerKind, const CHUNK_SIZE: usize> IterMut<'a, A, P, CHU
 }
 
 impl<'a, A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> IterMut<'a, A, P, CHUNK_SIZE> {
-    fn new(seq: &'a mut GenericVector<A, P, CHUNK_SIZE>) -> Self {
+    fn new(seq: &'a mut Vector<A, P, CHUNK_SIZE>) -> Self {
         let focus = seq.focus_mut();
         let len = focus.len();
         IterMut {
@@ -2222,11 +2229,11 @@ impl<'a, A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> FusedIterator
 
 /// A consuming iterator over vectors with values of type `A`.
 pub struct ConsumingIter<A, P: SharedPointerKind, const CHUNK_SIZE: usize> {
-    vector: GenericVector<A, P, CHUNK_SIZE>,
+    vector: Vector<A, P, CHUNK_SIZE>,
 }
 
 impl<A, P: SharedPointerKind, const CHUNK_SIZE: usize> ConsumingIter<A, P, CHUNK_SIZE> {
-    fn new(vector: GenericVector<A, P, CHUNK_SIZE>) -> Self {
+    fn new(vector: Vector<A, P, CHUNK_SIZE>) -> Self {
         Self { vector }
     }
 }
@@ -2282,7 +2289,7 @@ pub struct Chunks<'a, A, P: SharedPointerKind, const CHUNK_SIZE: usize> {
 }
 
 impl<'a, A, P: SharedPointerKind, const CHUNK_SIZE: usize> Chunks<'a, A, P, CHUNK_SIZE> {
-    fn new(seq: &'a GenericVector<A, P, CHUNK_SIZE>) -> Self {
+    fn new(seq: &'a Vector<A, P, CHUNK_SIZE>) -> Self {
         Chunks {
             focus: seq.focus(),
             front_index: 0,
@@ -2347,7 +2354,7 @@ pub struct ChunksMut<'a, A, P: SharedPointerKind, const CHUNK_SIZE: usize> {
 }
 
 impl<'a, A: Clone, P: SharedPointerKind, const CHUNK_SIZE: usize> ChunksMut<'a, A, P, CHUNK_SIZE> {
-    fn new(seq: &'a mut GenericVector<A, P, CHUNK_SIZE>) -> Self {
+    fn new(seq: &'a mut Vector<A, P, CHUNK_SIZE>) -> Self {
         let len = seq.len();
         ChunksMut {
             focus: seq.focus_mut(),
@@ -2451,7 +2458,7 @@ mod test {
             #[cfg(not(miri))]
             (0..100_000, vec![0, 1, 50_000, 99_999, 100_000]),
         ] {
-            let imbl_vec = Vector::from_iter(data.clone());
+            let imbl_vec = Vector::<i32>::from_iter(data.clone());
             let vec = Vec::from_iter(data);
             let focus = imbl_vec.focus();
             for split_point in split_points {
@@ -2472,7 +2479,7 @@ mod test {
     #[test]
     #[should_panic(expected = "range out of bounds")]
     fn test_vector_focus_narrow_out_of_range() {
-        let vec = Vector::from_iter(0..100);
+        let vec = Vector::<i32>::from_iter(0..100);
         _ = vec.focus().narrow(..1000);
     }
 
@@ -2509,7 +2516,7 @@ mod test {
     #[cfg_attr(miri, ignore)]
     #[test]
     fn large_vector_focus() {
-        let input = Vector::from_iter(0..100_000);
+        let input = Vector::<i64>::from_iter(0..100_000);
         let vec = input.clone();
         let mut sum: i64 = 0;
         let mut focus = vec.focus();
@@ -2523,7 +2530,7 @@ mod test {
     #[cfg_attr(miri, ignore)]
     #[test]
     fn large_vector_focus_mut() {
-        let input = Vector::from_iter(0..100_000);
+        let input = Vector::<i32>::from_iter(0..100_000);
         let mut vec = input.clone();
         {
             let mut focus = vec.focus_mut();
@@ -2541,9 +2548,9 @@ mod test {
     fn issue_55_fwd() {
         let mut l = Vector::new();
         for i in 0..4098 {
-            l.append(GenericVector::unit(i));
+            l.append(Vector::unit(i));
         }
-        l.append(GenericVector::unit(4098));
+        l.append(Vector::unit(4098));
         assert_eq!(Some(&4097), l.get(4097));
         assert_eq!(Some(&4096), l.get(4096));
     }
@@ -2551,9 +2558,9 @@ mod test {
     #[cfg_attr(miri, ignore)]
     #[test]
     fn issue_55_back() {
-        let mut l = Vector::unit(0);
+        let mut l = Vector::<i32>::unit(0);
         for i in 0..4099 {
-            let mut tmp = GenericVector::unit(i + 1);
+            let mut tmp = Vector::unit(i + 1);
             tmp.append(l);
             l = tmp;
         }
@@ -2565,15 +2572,15 @@ mod test {
 
     #[test]
     fn issue_55_append() {
-        let mut vec1 = Vector::from_iter(0..92);
-        let vec2 = GenericVector::from_iter(0..165);
+        let mut vec1 = Vector::<i32>::from_iter(0..92);
+        let vec2 = Vector::<i32>::from_iter(0..165);
         vec1.append(vec2);
     }
 
     #[test]
     fn issue_70() {
         // This tests assumes a chunk size of 64
-        let mut x = GenericVector::<i32, DefaultSharedPtr, 64>::new();
+        let mut x = Vector::<i32, DefaultSharedPtr, 64>::new();
         for _ in 0..262 {
             x.push_back(0);
         }
@@ -2613,9 +2620,9 @@ mod test {
     #[cfg_attr(miri, ignore)]
     #[test]
     fn issue_67() {
-        let mut l = Vector::unit(4100);
+        let mut l = Vector::<i32>::unit(4100);
         for i in (0..4099).rev() {
-            let mut tmp = GenericVector::unit(i);
+            let mut tmp = Vector::unit(i);
             tmp.append(l);
             l = tmp;
         }
@@ -2631,7 +2638,7 @@ mod test {
     #[test]
     fn issue_74_simple_size() {
         const CHUNK_SIZE: usize = 64;
-        let mut x = GenericVector::<u32, DefaultSharedPtr, CHUNK_SIZE>::new();
+        let mut x = Vector::<u32, DefaultSharedPtr, CHUNK_SIZE>::new();
         for _ in 0..(CHUNK_SIZE
             * (
                 1 // inner_f
@@ -2706,7 +2713,7 @@ mod test {
     #[cfg_attr(miri, ignore)]
     #[test]
     fn issue_107_split_off_causes_overflow() {
-        let mut vec = Vector::from_iter(0..4289);
+        let mut vec = Vector::<i32>::from_iter(0..4289);
         let mut control = Vec::from_iter(0..4289);
         let chunk = 64;
 
@@ -2727,7 +2734,7 @@ mod test {
 
     #[test]
     fn issue_116() {
-        let vec = Vector::from_iter(0..300);
+        let vec = Vector::<i32>::from_iter(0..300);
         let rev_vec: Vector<_> = vec.clone().into_iter().rev().collect();
         assert_eq!(vec.len(), rev_vec.len());
     }
@@ -2762,7 +2769,7 @@ mod test {
 
     #[test]
     fn full_retain() {
-        let mut a = Vector::from_iter(0..128);
+        let mut a = Vector::<i32>::from_iter(0..128);
         let b = Vector::from_iter(128..256);
         a.append(b);
         assert!(matches!(a.vector, Full(_)));
@@ -2777,7 +2784,7 @@ mod test {
         #[cfg_attr(miri, ignore)]
         #[test]
         fn iter(ref vec in vec(i32::ANY, 0..1000)) {
-            let seq = Vector::from_iter(vec.iter().cloned());
+            let seq = Vector::<i32>::from_iter(vec.iter().cloned());
             for (index, item) in seq.iter().enumerate() {
                 assert_eq!(&vec[index], item);
             }
@@ -2793,8 +2800,8 @@ mod test {
                 vector.push_front(value);
                 assert_eq!(count + 1, vector.len());
             }
-            let input2 = Vec::from_iter(input.iter().rev().cloned());
-            assert_eq!(input2, Vec::from_iter(vector.iter().cloned()));
+            let input2 = Vec::<i32>::from_iter(input.iter().rev().cloned());
+            assert_eq!(input2, Vec::<i32>::from_iter(vector.iter().cloned()));
         }
 
         #[cfg_attr(miri, ignore)]
@@ -2806,13 +2813,13 @@ mod test {
                 vector.push_back(value);
                 assert_eq!(count + 1, vector.len());
             }
-            assert_eq!(input, &Vec::from_iter(vector.iter().cloned()));
+            assert_eq!(input, &Vec::<i32>::from_iter(vector.iter().cloned()));
         }
 
         #[cfg_attr(miri, ignore)]
         #[test]
         fn pop_back_mut(ref input in vec(i32::ANY, 0..1000)) {
-            let mut vector = Vector::from_iter(input.iter().cloned());
+            let mut vector = Vector::<i32>::from_iter(input.iter().cloned());
             assert_eq!(input.len(), vector.len());
             for (index, value) in input.iter().cloned().enumerate().rev() {
                 match vector.pop_back() {
@@ -2829,7 +2836,7 @@ mod test {
         #[cfg_attr(miri, ignore)]
         #[test]
         fn pop_front_mut(ref input in vec(i32::ANY, 0..1000)) {
-            let mut vector = Vector::from_iter(input.iter().cloned());
+            let mut vector = Vector::<i32>::from_iter(input.iter().cloned());
             assert_eq!(input.len(), vector.len());
             for (index, value) in input.iter().cloned().rev().enumerate().rev() {
                 match vector.pop_front() {
@@ -2867,7 +2874,7 @@ mod test {
         #[test]
         fn skip(ref vec in vec(i32::ANY, 1..2000), count in usize::ANY) {
             let count = count % (vec.len() + 1);
-            let old = Vector::from_iter(vec.iter().cloned());
+            let old = Vector::<i32>::from_iter(vec.iter().cloned());
             let new = old.skip(count);
             assert_eq!(old.len(), vec.len());
             assert_eq!(new.len(), vec.len() - count);
@@ -2883,7 +2890,7 @@ mod test {
         #[test]
         fn split_off(ref vec in vec(i32::ANY, 1..2000), split_pos in usize::ANY) {
             let split_index = split_pos % (vec.len() + 1);
-            let mut left = Vector::from_iter(vec.iter().cloned());
+            let mut left = Vector::<i32>::from_iter(vec.iter().cloned());
             let right = left.split_off(split_index);
             assert_eq!(left.len(), split_index);
             assert_eq!(right.len(), vec.len() - split_index);
@@ -2898,8 +2905,8 @@ mod test {
         #[cfg_attr(miri, ignore)]
         #[test]
         fn append(ref vec1 in vec(i32::ANY, 0..1000), ref vec2 in vec(i32::ANY, 0..1000)) {
-            let mut seq1 = Vector::from_iter(vec1.iter().cloned());
-            let seq2 = Vector::from_iter(vec2.iter().cloned());
+            let mut seq1 = Vector::<i32>::from_iter(vec1.iter().cloned());
+            let seq2 = Vector::<i32>::from_iter(vec2.iter().cloned());
             assert_eq!(seq1.len(), vec1.len());
             assert_eq!(seq2.len(), vec2.len());
             seq1.append(seq2);
@@ -3112,13 +3119,10 @@ impl<
     }
 
     /// Produces an output vector from the input vector using a map function and a key extractor.
-    pub fn map(
-        &mut self,
-        from: &GenericVector<In, P, CHUNK_SIZE>,
-    ) -> GenericVector<Out, P, CHUNK_SIZE> {
+    pub fn map(&mut self, from: &Vector<In, P, CHUNK_SIZE>) -> Vector<Out, P, CHUNK_SIZE> {
         match &from.vector {
             Inline(next_in) => {
-                let mut next = GenericVector {
+                let mut next = Vector {
                     vector: VectorInner::Inline(InlineArray::new()),
                 };
 
@@ -3142,7 +3146,7 @@ impl<
                     Inline(chunk) => self.previous_out = Single(SharedPointer::new(chunk.into())),
                     Single(_) => (),
                     Full(_) => {
-                        let mut next = GenericVector {
+                        let mut next = Vector {
                             vector: VectorInner::Single(SharedPointer::new(Chunk::new())),
                         };
                         Self::map_next_in(
@@ -3177,12 +3181,12 @@ impl<
                             &mut self.f,
                         );
 
-                        GenericVector {
+                        Vector {
                             vector: VectorInner::Single(inner),
                         }
                     }
                     Inline(_) | Full(_) => {
-                        let mut next = GenericVector {
+                        let mut next = Vector {
                             vector: VectorInner::Single(SharedPointer::new(Chunk::new())),
                         };
                         Self::map_next_in(
@@ -3201,7 +3205,7 @@ impl<
                     }
                 }
             }
-            Full(rrb) => GenericVector {
+            Full(rrb) => Vector {
                 vector: VectorInner::Full(self.map_with_key_internal(rrb)),
             },
         }
@@ -3336,7 +3340,7 @@ impl<T: Clone, F: FnMut(T, T) -> T, P: SharedPointerKind, const CHUNK_SIZE: usiz
     }
 
     /// Produces an output value from the input vector using a fold operation
-    pub fn fold(&mut self, from: &GenericVector<T, P, CHUNK_SIZE>) -> Option<T> {
+    pub fn fold(&mut self, from: &Vector<T, P, CHUNK_SIZE>) -> Option<T> {
         match &from.vector {
             Inline(chunk) => {
                 if chunk.is_empty() {
@@ -3452,7 +3456,7 @@ fn test_vector_map_ref() {
 #[test]
 fn test_vector_map_big() {
     const COUNT: usize = 10000;
-    let mut a = Vector::from_iter((0..COUNT).map(|i| i as i64));
+    let mut a = Vector::<i64>::from_iter((0..COUNT).map(|i| i as i64));
     let mut mutation_count = 0;
 
     let len = {
@@ -3498,7 +3502,7 @@ fn test_vector_fold_big() {
     const COUNT: usize = 10000;
     const BASE: i64 = (COUNT * (COUNT + 1) / 2) as i64;
 
-    let mut a = Vector::from_iter((1..=COUNT).map(|i| i as i64));
+    let mut a = Vector::<i64>::from_iter((1..=COUNT).map(|i| i as i64));
     let mut mutation_count = 0;
 
     let mut fold = PersistentFold::<i64, _, _, _>::new(|l, r| {

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -3346,7 +3346,7 @@ impl<T: Clone, F: FnMut(T, T) -> T, P: SharedPointerKind, const CHUNK_SIZE: usiz
                 if chunk.is_empty() {
                     None
                 } else {
-                    Some(binary_fold(&chunk, &mut self.f))
+                    Some(binary_fold(chunk, &mut self.f))
                 }
             }
             Single(chunk) => {
@@ -3358,7 +3358,7 @@ impl<T: Clone, F: FnMut(T, T) -> T, P: SharedPointerKind, const CHUNK_SIZE: usiz
                     self.inner_f = FoldSeqStore::Empty;
                     None
                 } else {
-                    let result = binary_fold(&chunk, &mut self.f);
+                    let result = binary_fold(chunk, &mut self.f);
                     self.inner_f = FoldSeqStore::Values(result.clone(), chunk.clone());
                     Some(result)
                 }
@@ -3380,7 +3380,7 @@ impl<T: Clone, F: FnMut(T, T) -> T, P: SharedPointerKind, const CHUNK_SIZE: usiz
                     } else if chunk.is_empty() {
                         *old_node = FoldSeqStore::Empty;
                     } else {
-                        let result = binary_fold(&chunk, &mut self.f);
+                        let result = binary_fold(chunk, &mut self.f);
                         *old_node = FoldSeqStore::Values(result.clone(), chunk.clone());
                         outer.push_back(result);
                     }

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -49,7 +49,6 @@ use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::fmt::{Debug, Error, Formatter};
 use std::hash::{Hash, Hasher};
-use std::io::Chain;
 use std::iter::Sum;
 use std::iter::{FromIterator, FusedIterator};
 use std::mem::{replace, swap};

--- a/src/vector/rayon.rs
+++ b/src/vector/rayon.rs
@@ -9,7 +9,7 @@ use ::rayon::iter::{
 };
 
 impl<'a, A, P: SharedPointerKind, const CHUNK_SIZE: usize> IntoParallelRefIterator<'a>
-    for GenericVector<A, P, CHUNK_SIZE>
+    for Vector<A, P, CHUNK_SIZE>
 where
     A: Clone + Send + Sync + 'a,
     P: SharedPointerKind + Send + 'a,
@@ -25,7 +25,7 @@ where
 }
 
 impl<'a, A, P, const CHUNK_SIZE: usize> IntoParallelRefMutIterator<'a>
-    for GenericVector<A, P, CHUNK_SIZE>
+    for Vector<A, P, CHUNK_SIZE>
 where
     A: Clone + Send + Sync + 'a,
     P: SharedPointerKind + Send + Sync + 'a,

--- a/src/vector/rayon.rs
+++ b/src/vector/rayon.rs
@@ -3,7 +3,7 @@
 //! These are only available when using the `rayon` feature flag.
 
 use super::*;
-use ::rayon::iter::plumbing::{bridge, Consumer, Producer, ProducerCallback, UnindexedConsumer};
+use ::rayon::iter::plumbing::{Consumer, Producer, ProducerCallback, UnindexedConsumer, bridge};
 use ::rayon::iter::{
     IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
 };
@@ -24,8 +24,7 @@ where
     }
 }
 
-impl<'a, A, P, const CHUNK_SIZE: usize> IntoParallelRefMutIterator<'a>
-    for Vector<A, P, CHUNK_SIZE>
+impl<'a, A, P, const CHUNK_SIZE: usize> IntoParallelRefMutIterator<'a> for Vector<A, P, CHUNK_SIZE>
 where
     A: Clone + Send + Sync + 'a,
     P: SharedPointerKind + Send + Sync + 'a,


### PR DESCRIPTION
This PR is a large refactor and update of the library, moving it to Rust 2024, updating the rust version and updating most of the dependencies (I opted to ignore the bincode situation #146 for now, though). It also adds a persistent map and fold to the Vector, which I needed for a library, but this shouldn't impact the API.

The major change here is to get rid of the `Generic*` versions of the structs and instead use default type arguments, while providing a `new()` function using the default type arguments and `with_*` functions that provide more granular control. This mirrors how the standard library handles things. In most cases, simply replacing `GenericName` with `Name` will suffice in current user code, but it does require using explicit arguments in two cases: `::<_>::from_iter()` and `::<_>::unit()`.

In addition, the RRB data structure and everything that depends on it (like `Vector`) was changed to use a compiler-time `CHUNK_SIZE` constant. To be more consistent, this change should also be applied to the btree's `NODE_SIZE`, which was previously requested (#145) but I'm not currently using the btree. This should at least give you an idea of what the consequences of moving to a const generic will be in case you have your own plans for that.

This is a substantial breaking change to the library API, which would require yet another version increment - apparently the version was just updated to `7.0` a few weeks ago. I don't actually know who the primary users of this library are, so I am offering this PR just in case the current maintainers are interested in any of these changes.