### PR TITLE
bugfix!: over advancing in `Cursor::advance_skipping_shared`

### DIFF
--- a/src/nodes/btree.rs
+++ b/src/nodes/btree.rs
@@ -1188,8 +1188,8 @@ impl<'a, K, V, P: SharedPointerKind> Cursor<'a, K, V, P> {
         // The current implementation is not optimal as it will still visit many nodes unnecessarily
         // before skipping them. But it requires very little additional code.
         // Nevertheless it will still improve performance when there are shared nodes.
+        let mut skipped_any = false;
         loop {
-            let mut skipped_any = false;
             debug_assert!(self.leaf.is_some());
             debug_assert!(other.leaf.is_some());
             if let (Some(this), Some(that)) = (self.leaf, other.leaf) {
@@ -1208,13 +1208,22 @@ impl<'a, K, V, P: SharedPointerKind> Cursor<'a, K, V, P> {
                         self.stack.drain(self.stack.len() - shared_levels..);
                         other.stack.drain(other.stack.len() - shared_levels..);
                     }
+                    self.next();
+                    other.next();
+                    if self.leaf.is_none() {
+                        break;
+                    }
+                    continue;
                 }
             }
-            self.next();
-            other.next();
-            if !skipped_any || self.leaf.is_none() {
-                break;
+            // The current leaves are not shared. If we already skipped a shared
+            // node we have re-descended onto a fresh leaf and must not advance
+            // past its first element; otherwise perform the single-step advance.
+            if !skipped_any {
+                self.next();
+                other.next();
             }
+            break;
         }
     }
 

--- a/src/ord/map.rs
+++ b/src/ord/map.rs
@@ -2630,6 +2630,24 @@ mod test {
         }
     }
 
+    #[test]
+    fn diff_shared_single_update() {
+        // 17 sequential keys is the minimum that splits into two leaves. Nodes
+        // contain 16 entries, and after inserting the 17th, we split at `MEDIAN`.
+        // Thus, leaf 0 contains keys [0, 7] and leaf 1 [8, 16].
+        //
+        // Updating the map with `(8, 999)`, changes the index-0 value of
+        // leaf 1.
+        //
+        // `Cursor::advance_skipping_shared` used to over advance and skip this
+        // element in its comparison. The following test case guards against a
+        // regression in this behavior.
+        let a: OrdMap<i64, i64> = (0..17).map(|i| (i, 0)).collect();
+        let b = a.update(8, 999);
+        assert_eq!(a.diff(&b).count(), 1);
+        assert_ne!(a, b);
+    }
+
     fn expected_diff<'a, K, V, P>(
         a: &'a GenericOrdMap<K, V, P>,
         b: &'a GenericOrdMap<K, V, P>,


### PR DESCRIPTION
### Bug

When `Cursor::advance_skipping_shared` finds equal leaves from the two cursors being compared, the index 0 element of the next non-shared leaf is skipped.

The buggy behavior that causes this issue is:
1. find a shared leaf between the two cursors
2. set the leavs of both `Cursors` to `None` and update the respective stacks to the next non-shared leaf
3. call `.next()` on both cursors, now referencing index 0 of the non-shared leaves
4. go back to the top of the loop, `skipped_any == false` and the leaves are not shared
5. call `.next()` on both cursors again, **advancing both cursors to index 1 (the bug)**

### Summary

The first commit of this PR is a failing test that exhibits the bug, the second commit are the requires changes to fix it.

_AI disclosure_: I didn't see any references to AI usage in your code of conduct, but wanted to callout that I used Claude to help me root cause the issue and implement a fix. I reviewed the change in the context of the codebase, and to the best of my knowledge this is the right fix, but wanted to be transparent in my use of AI :) 

Fixes https://github.com/jneem/imbl/issues/161