### PR TITLE
Fix 7 doc links that weren't displaying correctly.

### DIFF
--- a/src/hash/map.rs
+++ b/src/hash/map.rs
@@ -87,7 +87,7 @@ pub type HashMap<K, V> = GenericHashMap<K, V, RandomState, DefaultSharedPtr>;
 
 /// An unordered map.
 ///
-/// An immutable hash map using [hash array mapped tries] [1].
+/// An immutable hash map using [hash array mapped tries][1].
 ///
 /// Most operations on this map are O(log<sub>x</sub> n) for a
 /// suitably high *x* that it should be nearly O(1) for most maps.

--- a/src/hash/set.rs
+++ b/src/hash/set.rs
@@ -4,7 +4,7 @@
 
 //! An unordered set.
 //!
-//! An immutable hash set using [hash array mapped tries] [1].
+//! An immutable hash set using [hash array mapped tries][1].
 //!
 //! Most operations on this set are O(log<sub>x</sub> n) for a
 //! suitably high *x* that it should be nearly O(1) for most sets.
@@ -81,7 +81,7 @@ pub type HashSet<A> = GenericHashSet<A, RandomState, DefaultSharedPtr>;
 
 /// An unordered set.
 ///
-/// An immutable hash set using [hash array mapped tries] [1].
+/// An immutable hash set using [hash array mapped tries][1].
 ///
 /// Most operations on this set are O(log<sub>x</sub> n) for a
 /// suitably high *x* that it should be nearly O(1) for most sets.

--- a/src/ord/map.rs
+++ b/src/ord/map.rs
@@ -4,7 +4,7 @@
 
 //! An ordered map.
 //!
-//! An immutable ordered map implemented as a [B+tree] [1].
+//! An immutable ordered map implemented as a [B+ tree][1].
 //!
 //! Most operations on this type of map are O(log n). A
 //! [`HashMap`][hashmap::HashMap] is usually a better choice for
@@ -74,7 +74,7 @@ pub type OrdMap<K, V> = GenericOrdMap<K, V, DefaultSharedPtr>;
 
 /// An ordered map.
 ///
-/// An immutable ordered map implemented as a B+tree [1].
+/// An immutable ordered map implemented as a [B+ tree][1].
 ///
 /// Most operations on this type of map are O(log n). A
 /// [`HashMap`][hashmap::HashMap] is usually a better choice for

--- a/src/ord/set.rs
+++ b/src/ord/set.rs
@@ -4,7 +4,7 @@
 
 //! An ordered set.
 //!
-//! An immutable ordered set implemented as a [B+tree] [1].
+//! An immutable ordered set implemented as a [B+ tree][1].
 //!
 //! Most operations on this type of set are O(log n). A
 //! [`GenericHashSet`] is usually a better choice for
@@ -66,7 +66,7 @@ pub type OrdSet<A> = GenericOrdSet<A, DefaultSharedPtr>;
 
 /// An ordered set.
 ///
-/// An immutable ordered map implemented as a B+tree [1].
+/// An immutable ordered map implemented as a [B+ tree][1].
 ///
 /// Most operations on this type of set are O(log n). A
 /// [`GenericHashSet`] is usually a better choice for


### PR DESCRIPTION
I noticed that these weren't looking quite right on docs.rs, with the hyperlink text just reading "1". Two main issues:

- Stray spaces between link text and reference label
- Missing square brackets around link text

Also, I think the "B+ tree" link text reads better with a space, but that's just preference rather than correctness.