### PR TITLE
Add `Clone` impl for various `ConsumingIter`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Implemented `Clone` for the consuming iterators of `HashMap`, `HashSet`,
+  `OrdMap`, `OrdSet` and `Vector`. (#174)
+
 ### Changed
 
 - Removed the `bitmaps` dependency, which is unmaintained (RUSTSEC-2026-0247)

--- a/src/hash/map.rs
+++ b/src/hash/map.rs
@@ -1969,6 +1969,14 @@ pub struct ConsumingIter<A: HashValue, P: SharedPointerKind> {
     it: NodeDrain<A, P>,
 }
 
+impl<A: HashValue, P: SharedPointerKind> Clone for ConsumingIter<A, P> {
+    fn clone(&self) -> Self {
+        Self {
+            it: self.it.clone(),
+        }
+    }
+}
+
 impl<A, P: SharedPointerKind> Iterator for ConsumingIter<A, P>
 where
     A: HashValue + Clone,

--- a/src/hash/set.rs
+++ b/src/hash/set.rs
@@ -803,6 +803,18 @@ where
     it: NodeDrain<Value<A>, P>,
 }
 
+impl<A, P> Clone for ConsumingIter<A, P>
+where
+    A: Hash + Eq + Clone,
+    P: SharedPointerKind,
+{
+    fn clone(&self) -> Self {
+        Self {
+            it: self.it.clone(),
+        }
+    }
+}
+
 impl<A, P> Iterator for ConsumingIter<A, P>
 where
     A: Hash + Eq + Clone,

--- a/src/nodes/btree.rs
+++ b/src/nodes/btree.rs
@@ -805,6 +805,15 @@ pub(crate) struct ConsumingIter<K, V, P: SharedPointerKind> {
     remaining: usize,
 }
 
+impl<K, V, P: SharedPointerKind> Clone for ConsumingIter<K, V, P> {
+    fn clone(&self) -> Self {
+        Self {
+            leaves: self.leaves.clone(),
+            remaining: self.remaining,
+        }
+    }
+}
+
 impl<K, V, P: SharedPointerKind> ConsumingIter<K, V, P> {
     pub(crate) fn new(node: Option<Node<K, V, P>>, size: usize) -> Self {
         fn push<K, V, P: SharedPointerKind>(

--- a/src/nodes/hamt.rs
+++ b/src/nodes/hamt.rs
@@ -979,9 +979,29 @@ enum DrainItem<A, P: SharedPointerKind> {
     Collision(SharedPointer<CollisionNode<A>, P>),
 }
 
+impl<A, P: SharedPointerKind> Clone for DrainItem<A, P> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::SmallSimdNode(arg0) => Self::SmallSimdNode(arg0.clone()),
+            Self::LargeSimdNode(arg0) => Self::LargeSimdNode(arg0.clone()),
+            Self::HamtNode(arg0) => Self::HamtNode(arg0.clone()),
+            Self::Collision(arg0) => Self::Collision(arg0.clone()),
+        }
+    }
+}
+
 pub(crate) struct Drain<A, P: SharedPointerKind> {
     count: usize,
     stack: InlineStack<DrainItem<A, P>>,
+}
+
+impl<A, P: SharedPointerKind> Clone for Drain<A, P> {
+    fn clone(&self) -> Self {
+        Self {
+            count: self.count,
+            stack: self.stack.clone(),
+        }
+    }
 }
 
 impl<A, P: SharedPointerKind> Drain<A, P> {

--- a/src/ord/map.rs
+++ b/src/ord/map.rs
@@ -2127,6 +2127,14 @@ pub struct ConsumingIter<K, V, P: SharedPointerKind> {
     it: NodeConsumingIter<K, V, P>,
 }
 
+impl<K, V, P: SharedPointerKind> Clone for ConsumingIter<K, V, P> {
+    fn clone(&self) -> Self {
+        Self {
+            it: self.it.clone(),
+        }
+    }
+}
+
 impl<K, V, P> Iterator for ConsumingIter<K, V, P>
 where
     K: Clone,

--- a/src/ord/set.rs
+++ b/src/ord/set.rs
@@ -930,6 +930,14 @@ pub struct ConsumingIter<A, P: SharedPointerKind> {
     it: map::ConsumingIter<A, (), P>,
 }
 
+impl<A, P: SharedPointerKind> Clone for ConsumingIter<A, P> {
+    fn clone(&self) -> Self {
+        Self {
+            it: self.it.clone(),
+        }
+    }
+}
+
 impl<A, P> Iterator for ConsumingIter<A, P>
 where
     A: Clone,

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -2169,6 +2169,14 @@ pub struct ConsumingIter<A, P: SharedPointerKind> {
     vector: GenericVector<A, P>,
 }
 
+impl<A: Clone, P: SharedPointerKind> Clone for ConsumingIter<A, P> {
+    fn clone(&self) -> Self {
+        Self {
+            vector: self.vector.clone(),
+        }
+    }
+}
+
 impl<A, P: SharedPointerKind> ConsumingIter<A, P> {
     fn new(vector: GenericVector<A, P>) -> Self {
         Self { vector }


### PR DESCRIPTION
Since all data structures are immutable, one should be able to clone the consuming iterators. I have implemented this.