### PR TITLE
Drop the unmaintained bitmaps dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Removed the `bitmaps` dependency, which is unmaintained (RUSTSEC-2026-0247)
+  and carries an unpatched soundness issue (RUSTSEC-2025-0167), by using
+  `imbl-sized-chunks` 0.2.0's in-tree bitmap module. No public API change. (#170)
+
 ## [7.0.1] - 2026-07-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,12 +76,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
 
 [[package]]
-name = "bitmaps"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
-
-[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,7 +305,6 @@ dependencies = [
  "arbitrary",
  "archery",
  "bincode",
- "bitmaps",
  "criterion",
  "equivalent",
  "half",
@@ -335,12 +328,9 @@ dependencies = [
 
 [[package]]
 name = "imbl-sized-chunks"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
-dependencies = [
- "bitmaps",
-]
+checksum = "2a0813be332553f857953298749fa19549e8b61b80589757c29b4e2a804fa9c6"
 
 [[package]]
 name = "itertools"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,7 @@ small-chunks = []
 triomphe = ["archery/triomphe"]
 
 [dependencies]
-bitmaps = "3"
-imbl-sized-chunks = "0.1.3"
+imbl-sized-chunks = "0.2.0"
 rand_core = "0.9"
 rand_xoshiro = "0.7"
 archery = "1.2.1"

--- a/src/nodes/hamt.rs
+++ b/src/nodes/hamt.rs
@@ -10,8 +10,8 @@ use std::slice::{Iter as SliceIter, IterMut as SliceIterMut};
 use std::{fmt, mem, ptr};
 
 use archery::{SharedPointer, SharedPointerKind};
-use bitmaps::{Bits, BitsImpl};
 use equivalent::Equivalent;
+use imbl_sized_chunks::bitmap::{Bits, BitsImpl};
 use imbl_sized_chunks::inline_array::InlineArray;
 use imbl_sized_chunks::sparse_chunk::{Iter as ChunkIter, IterMut as ChunkIterMut, SparseChunk};
 
@@ -24,7 +24,7 @@ const SMALL_NODE_WIDTH: usize = HASH_WIDTH / 2;
 const GROUP_WIDTH: usize = HASH_WIDTH / 2;
 
 type SimdGroup = wide::u8x16;
-type GroupBitmap = bitmaps::Bitmap<GROUP_WIDTH>;
+type GroupBitmap = imbl_sized_chunks::bitmap::Bitmap<GROUP_WIDTH>;
 
 const _: () = {
     // Limitations of the current implementation, can only handle up to 2 groups,


### PR DESCRIPTION
Removes the `bitmaps` dependency responsible for **RUSTSEC-2026-0247** and **RUSTSEC-2025-0167** that trips `cargo-audit`/`cargo-deny` user of imbl downstream. Upgrade   `imbl-sized-chunks` 0.2.0 which also removes it jneem/imbl-sized-chunks#17.

Fixes #170.