### PR TITLE
ord: fix OrdSet::ConsumingIter ExactSizeIterator::len panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   and carries an unpatched soundness issue (RUSTSEC-2025-0167), by using
   `imbl-sized-chunks` 0.2.0's in-tree bitmap module. No public API change. (#170)
 
+### Fixed
+
+- Fixed `OrdSet::ConsumingIter::len()` panicking due to a missing `size_hint`
+  override on its `ExactSizeIterator` implementation. (#176)
+
 ## [7.0.1] - 2026-07-18
 
 ### Fixed

--- a/src/ord/set.rs
+++ b/src/ord/set.rs
@@ -943,6 +943,10 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         self.it.next().map(|v| v.0)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.it.size_hint()
+    }
 }
 
 impl<A, P> DoubleEndedIterator for ConsumingIter<A, P>
@@ -1154,6 +1158,15 @@ mod test {
         assert!(!set.contains("bar"));
         set.remove("foo");
         assert!(!set.contains("foo"));
+    }
+
+    #[test]
+    fn consuming_iter_len() {
+        let set = ordset![1, 2, 3, 4, 5];
+        let mut it = set.into_iter();
+        assert_eq!(it.len(), 5);
+        it.next();
+        assert_eq!(it.len(), 4);
     }
 
     #[test]


### PR DESCRIPTION
`OrdSet::ConsumingIter` implements `ExactSizeIterator` but never overrides `size_hint`, so calling `.len()` panics via core's `ExactSizeIterator` default. Repro: `OrdSet::from_iter(0..10).into_iter().len()`.

Forward `size_hint` to the inner map iterator; adds a regression test.