### PR TITLE
Release 7.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [7.0.2] - 2026-09-09
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "imbl"
-version = "7.0.1"
+version = "7.1.0"
 dependencies = [
  "arbitrary",
  "archery",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imbl"
-version = "7.0.1"
+version = "7.0.2"
 authors = [
     "Bodil Stokke <bodil@bodil.org>",
     "Joe Neeman <joeneeman@gmail.com>",


### PR DESCRIPTION
Bump version and date the changelog. Contents: Clone for consuming iterators (#174), bitmaps dependency removal (#175), OrdSet ConsumingIter len() fix (#176), OrdMap::diff shared-node fix (#166/#161).